### PR TITLE
spec add file tools dump-resolutions

### DIFF
--- a/rpm/gst-droid.spec
+++ b/rpm/gst-droid.spec
@@ -73,3 +73,4 @@ rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/gst-droid
 %defattr(-,root,root,-)
 %{_bindir}/mk-cam-conf
 %{_bindir}/record-video
+%{_bindir}/dump-resolutions


### PR DESCRIPTION
atm building gst-droid is failing because this unpackaged file
