### PR TITLE
[camera] Leave colour format to the droid recorder. Contributes JB#37491

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrcrecorder.c
+++ b/gst/droidcamsrc/gstdroidcamsrcrecorder.c
@@ -67,9 +67,6 @@ gst_droidcamsrc_recorder_init (GstDroidCamSrcRecorder * recorder,
 
   recorder->md.bitrate = target_bitrate;
 
-  /* set the color format */
-  recorder->md.color_format = droid_media_camera_get_video_color_format (cam);
-
   recorder->recorder = droid_media_recorder_create (cam, &recorder->md);
 
   if (!recorder->recorder) {


### PR DESCRIPTION
It's already creating a CameraSource, which is expensive and evicts existing clients in Android 6.