### PR TITLE
[pkgconfig] Add pkgconfig support, and fix devel package. MER#1837

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,8 @@
 SUBDIRS = common gst-libs gst tools
 
-EXTRA_DIST = autogen.sh
+EXTRA_DIST = autogen.sh \
+	gstreamer-droid-1.0.pc.in \
+	gstreamer-droid-1.0.pc
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = gstreamer-droid-1.0.pc

--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,7 @@ AC_DEFINE_UNQUOTED(GST_API_VERSION, "$GST_API_VERSION",
    [GStreamer API Version])
 
 AC_CONFIG_FILES([Makefile
+		gstreamer-droid-1.0.pc
 		common/Makefile
 		common/m4/Makefile
 		gst-libs/Makefile

--- a/gst-libs/gst/droid/gstdroidcodec.c
+++ b/gst-libs/gst/droid/gstdroidcodec.c
@@ -31,7 +31,7 @@
 #endif /* GST_USE_UNSTABLE_API */
 #include <gst/codecparsers/gsth264parser.h>
 
-GST_DEBUG_CATEGORY_EXTERN (gst_droid_codec_debug);
+GST_DEBUG_CATEGORY (gst_droid_codec_debug);
 #define GST_CAT_DEFAULT gst_droid_codec_debug
 
 static GstBuffer *create_mpeg4venc_codec_data (DroidMediaData * data);

--- a/gst-libs/gst/droid/gstdroidmediabuffer.h
+++ b/gst-libs/gst/droid/gstdroidmediabuffer.h
@@ -23,7 +23,7 @@
 
 #include <gst/gst.h>
 #include <gst/video/video.h>
-#include "droidmedia.h"
+#include <droidmedia/droidmedia.h>
 
 G_BEGIN_DECLS
 

--- a/gstreamer-droid-1.0.pc.in
+++ b/gstreamer-droid-1.0.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@/gstreamer-1.0
+
+Name: GstDroid library
+Description: GstDroid library
+Requires: gstreamer-1.0 gstreamer-base-1.0 android-headers
+Version: @VERSION@
+Libs: -L${libdir} -lgstdroid-1.0
+Cflags: -I${includedir}

--- a/rpm/gst-droid.spec
+++ b/rpm/gst-droid.spec
@@ -69,6 +69,7 @@ rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/gst-droid
 %defattr(-,root,root,-)
 %{_includedir}/gstreamer-%{majorminor}/gst/
 %{_libdir}/*.so
+%{_libdir}/pkgconfig/gstreamer-droid-1.0.pc
 
 %files tools
 %defattr(-,root,root,-)


### PR DESCRIPTION
Devel packages was a bit broken before, and gst-droid could not be built against by other packages. This fixes it and adds a pkgconfig file to make it easier. This is in preparation for gst-omx, but doesn't actually change the functionality of gst-droid.