### PR TITLE
[vdec] Fix colour conversion on MTK. Fixes JB#41376

### DIFF
--- a/gst-libs/gst/droid/gstdroidcodec.c
+++ b/gst-libs/gst/droid/gstdroidcodec.c
@@ -1104,6 +1104,7 @@ gst_droid_codec_type_fill_quirks (GstDroidCodec * codec)
     goto out;
   }
 
+  codec->quirks = 0;
   for (x = 0; x < quirks_length; x++) {
     if (!g_strcmp0 (quirks_string[x], USE_CODEC_SUPPLIED_HEIGHT_NAME)) {
       codec->quirks |= USE_CODEC_SUPPLIED_HEIGHT_VALUE;

--- a/gst/droidcodec/gstdroidvdec.h
+++ b/gst/droidcodec/gstdroidvdec.h
@@ -81,6 +81,7 @@ struct _GstDroidVDec
   GstVideoCodecState *in_state;
   GstVideoCodecState *out_state;
   DroidMediaConvert *convert;
+  gint32 hal_format;
 };
 
 struct _GstDroidVDecClass


### PR DESCRIPTION
- Use new hal_format property to choose the right colour conversion
  routine, or give an error if there isn't one.
- Implement straight copy with cropping for I420 buffers.