### PR TITLE
Memory leaks

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrcphotography.c
+++ b/gst/droidcamsrc/gstdroidcamsrcphotography.c
@@ -807,6 +807,8 @@ gst_droidcamsrc_photography_load (GKeyFile * file, const gchar * property)
     }
   }
 
+  g_strfreev(keys);
+
   return list;
 }
 

--- a/gst/droidcamsrc/gstdroidcamsrcrecorder.c
+++ b/gst/droidcamsrc/gstdroidcamsrcrecorder.c
@@ -85,6 +85,10 @@ void
 gst_droidcamsrc_recorder_update_vid (GstDroidCamSrcRecorder * recorder,
     GstVideoInfo * info, GstCaps * caps)
 {
+  if (recorder->codec) {
+    gst_droid_codec_unref (recorder->codec);
+  }
+
   recorder->codec =
       gst_droid_codec_new_from_caps (caps, GST_DROID_CODEC_ENCODER_VIDEO);
   recorder->md.parent.width = info->width;


### PR DESCRIPTION
```
==24317== 496 (320 direct, 176 indirect) bytes in 8 blocks are definitely lost in loss record 8,483 of 8,762
==24317==    at 0x483F3EC: malloc (vg_replace_malloc.c:299)
==24317==    by 0x73860DF: g_malloc (gmem.c:94)
==24317==    by 0x7379391: g_key_file_get_keys (gkeyfile.c:1565)
==24317==    by 0xF5016AD: gst_droidcamsrc_photography_load (gstdroidcamsrcphotography.c:783)
==24317==    by 0xF501E3F: gst_droidcamsrc_photography_init (gstdroidcamsrcphotography.c:660)
==24317==    by 0xF4FCCBF: gst_droidcamsrc_set_property (gstdroidcamsrc.c:329)
==24317==    by 0x762B1C3: object_set_property (gobject.c:1421)
==24317==    by 0x762B1C3: g_object_set_valist (gobject.c:2165)
==24317==    by 0x762B79F: g_object_set (gobject.c:2275)
==24317==    by 0xF0F15B9: QGstUtils::enumerateCameras(_GstElementFactory*) (in /usr/lib/libqgsttools_p.so.1.0.0)
```
```
==26481== 56 (48 direct, 8 indirect) bytes in 1 blocks are definitely lost in loss record 7,035 of 8,714
==26481==    at 0x483F3EC: malloc (vg_replace_malloc.c:299)
==26481==    by 0x73860DF: g_malloc (gmem.c:94)
==26481==    by 0x739BF51: g_slice_alloc (gslice.c:1025)
==26481==    by 0xD51F8CD: gst_droid_codec_new_from_caps (gstdroidcodec.c:159)
==26481==    by 0xD4F8D79: gst_droidcamsrc_recorder_update_vid (gstdroidcamsrcrecorder.c:89)
==26481==    by 0xD4EE155: gst_droidcamsrc_vidsrc_negotiate (gstdroidcamsrc.c:1738)
==26481==    by 0xD4F85D7: gst_droidcamsrc_mode_negotiate_pad.isra.0 (gstdroidcamsrcmode.c:200)
==26481==    by 0xD4F87B3: gst_droidcamsrc_mode_activate (gstdroidcamsrcmode.c:90)
==26481==    by 0xD4EDA55: gst_droidcamsrc_select_and_activate_mode (gstdroidcamsrc.c:2195)
==26481==    by 0xD4F13BB: gst_droidcamsrc_change_state (gstdroidcamsrc.c:615)
==26481==    by 0xD30482D: gst_element_change_state (gstelement.c:2695)
==26481==    by 0xD304E0B: gst_element_set_state_func (gstelement.c:2649)
==26481==    by 0xD2EB47F: gst_bin_element_set_state (gstbin.c:2619)
==26481==    by 0xD2EB47F: gst_bin_change_state_func (gstbin.c:2961)
==26481==    by 0xE359E21: ??? (in /usr/lib/gstreamer-1.0/libgstcamerabin2.so)
==26481==    by 0xD30482D: gst_element_change_state (gstelement.c:2695)
==26481==    by 0xD304885: gst_element_change_state (gstelement.c:2741)
==26481==    by 0xD304E0B: gst_element_set_state_func (gstelement.c:2649)
==26481==    by 0xD0A8225: ??? (in /usr/lib/qt5/plugins/mediaservice/libgstcamerabin.so)
```