### PR TITLE
[camera] Support "iso-speed" ISO setting variant. JB#41363

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -51,6 +51,12 @@ out:
   g_strfreev (parts);
 }
 
+gboolean
+gst_droidcamsrc_has_param (GstDroidCamSrcParams * params, const char *key)
+{
+  return g_hash_table_contains (params->params, key);
+}
+
 static int
 gst_droidcamsrc_params_get_int_locked (GstDroidCamSrcParams * params,
     const char *key)

--- a/gst/droidcamsrc/gstdroidcamsrcparams.h
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.h
@@ -38,6 +38,7 @@ struct _GstDroidCamSrcParams
 
 GstDroidCamSrcParams * gst_droidcamsrc_params_new (const gchar * params);
 void gst_droidcamsrc_params_destroy (GstDroidCamSrcParams *params);
+gboolean gst_droidcamsrc_has_param (GstDroidCamSrcParams * params, const char *key);
 void gst_droidcamsrc_params_reload (GstDroidCamSrcParams *params, const gchar * str);
 
 gchar *gst_droidcamsrc_params_to_string (GstDroidCamSrcParams *params);
@@ -47,8 +48,7 @@ GstCaps *gst_droidcamsrc_params_get_viewfinder_caps (GstDroidCamSrcParams *param
 GstCaps *gst_droidcamsrc_params_get_video_caps (GstDroidCamSrcParams *params);
 GstCaps *gst_droidcamsrc_params_get_image_caps (GstDroidCamSrcParams *params);
 
-void gst_droidcamsrc_params_set_string (GstDroidCamSrcParams *params, const gchar *key,
-					const gchar *value);
+void gst_droidcamsrc_params_set_string (GstDroidCamSrcParams *params, const gchar *key, const gchar *value);
 const gchar *gst_droidcamsrc_params_get_string (GstDroidCamSrcParams * params, const char *key);
 int gst_droidcamsrc_params_get_int (GstDroidCamSrcParams * params, const char *key);
 float gst_droidcamsrc_params_get_float (GstDroidCamSrcParams * params, const char *key);

--- a/tools/gstdroidcamsrcconf.c
+++ b/tools/gstdroidcamsrcconf.c
@@ -123,6 +123,7 @@ struct Node
       ADD_ENTRY (GST_PHOTOGRAPHY_COLOR_TONE_MODE_AQUA, "aqua"),
       {NULL, -1}
     }},
+  // Qualcomm ISO values (e.g. ISO100) and Intel (iso-100)
   {"iso-values", "iso-speed", {
       ADD_ENTRY (0, "auto"),
       ADD_ENTRY (0, "iso-auto"),
@@ -138,6 +139,16 @@ struct Node
       ADD_ENTRY (3200, "ISO3200"),
       {NULL, -1}
     }},
+  // Mediatek ISO values
+  {"iso-speed-values", "iso-speed", {
+      ADD_ENTRY (0, "auto"),
+      ADD_ENTRY (100, "100"),
+      ADD_ENTRY (200, "200"),
+      ADD_ENTRY (400, "400"),
+      ADD_ENTRY (800, "800"),
+      ADD_ENTRY (1600, "1600"),
+      {NULL, -1}
+  }},
   {"antibanding-values", "flicker-mode", {
       ADD_ENTRY (GST_PHOTOGRAPHY_FLICKER_REDUCTION_OFF, "off"),
       ADD_ENTRY (GST_PHOTOGRAPHY_FLICKER_REDUCTION_50HZ, "50hz"),


### PR DESCRIPTION
Support checking device parameter key presence, so we can choose between "iso" and "iso-speed" for MTK