### PR TITLE
Add support for format OMX_COLOR_FormatYUV420SemiPlanar

### DIFF
--- a/gst-libs/gst/droid/gstdroidcodec.c
+++ b/gst-libs/gst/droid/gstdroidcodec.c
@@ -1110,6 +1110,8 @@ gst_droid_codec_type_fill_quirks (GstDroidCodec * codec)
       codec->quirks |= USE_CODEC_SUPPLIED_HEIGHT_VALUE;
     } else if (!g_strcmp0 (quirks_string[x], USE_CODEC_SUPPLIED_WIDTH_NAME)) {
       codec->quirks |= USE_CODEC_SUPPLIED_WIDTH_VALUE;
+    } else if (!g_strcmp0 (quirks_string[x], DONT_USE_DROID_CONVERT_NAME)) {
+      codec->quirks |= DONT_USE_DROID_CONVERT_VALUE;
     }
   }
 

--- a/gst-libs/gst/droid/gstdroidcodec.h
+++ b/gst-libs/gst/droid/gstdroidcodec.h
@@ -35,6 +35,9 @@ G_BEGIN_DECLS
 #define USE_CODEC_SUPPLIED_WIDTH_NAME    "use-codec-supplied-width"
 #define USE_CODEC_SUPPLIED_WIDTH_VALUE   0x2
 
+#define DONT_USE_DROID_CONVERT_NAME    "dont-use-droid-convert"
+#define DONT_USE_DROID_CONVERT_VALUE   0x4
+
 typedef struct _GstDroidCodec GstDroidCodec;
 typedef struct _GstDroidCodecInfo GstDroidCodecInfo;
 typedef struct _GstDroidCodecPrivate GstDroidCodecPrivate;

--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -279,6 +279,11 @@ gst_droidvdec_convert_buffer (GstDroidVDec * dec,
   use_external_buffer = use_droid_convert && gst_buffer_get_size (out) != size;
   map_info.data = NULL;
 
+  if (dec->codec_type->quirks & DONT_USE_DROID_CONVERT_VALUE) {
+    use_droid_convert = false;
+    GST_INFO_OBJECT (dec, "not using droid convert binary");
+  }
+
   if (!gst_buffer_map (out, &map_info, GST_MAP_WRITE)) {
     GST_ERROR_OBJECT (dec, "failed to map buffer");
     ret = FALSE;

--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -377,6 +377,25 @@ gst_droidvdec_convert_buffer (GstDroidVDec * dec,
       gst_droidvec_copy_packed_planes (map_info.data + info->offset[1],
           map_info.data + info->offset[2], info->stride[1], uv, stride,
           info->width / 2, info->height / 2);
+
+    } else if (dec->hal_format == c.OMX_COLOR_FormatYUV420SemiPlanar) {
+      GST_DEBUG_OBJECT (dec,
+          "Converting from OMX_COLOR_FormatYUV420SemiPlanar");
+      gint stride = width;
+      gint slice_height = ALIGN_SIZE (height, 16);
+      gint top = dec->crop_rect.top;
+      gint left = dec->crop_rect.left;
+
+      guint8 *y = in->data + (top * stride) + left;
+      guint8 *uv =
+          in->data + (stride * slice_height) + (top * stride / 2) + left;
+
+      gst_droidvec_copy_plane (map_info.data + info->offset[0],
+          info->stride[0], y, stride, info->width, info->height);
+      gst_droidvec_copy_packed_planes (map_info.data + info->offset[1],
+          map_info.data + info->offset[2], info->stride[1], uv, stride,
+          info->width / 2, info->height / 2);
+
     } else {
       GST_ELEMENT_ERROR (dec, LIBRARY, FAILED, (NULL),
           ("Unknown codec colour format: %d", dec->hal_format));


### PR DESCRIPTION
This makes video playback work on mido, so long as the blob libI420colorconverter.so is removed, which seems to output in a format other that I420