### PR TITLE
Map 420 planar to YV12 when dealing with hardware buffers.

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrcdev.c
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.c
@@ -566,7 +566,7 @@ gst_droidcamsrc_dev_open (GstDroidCamSrcDev * dev, GstDroidCamSrcCamInfo * info)
   hal_format = droid_media_camera_get_video_color_format (dev->cam);
 
   if (hal_format == constants.OMX_COLOR_FormatYUV420Planar) {
-    dev->viewfinder_format = GST_VIDEO_FORMAT_I420;
+    dev->viewfinder_format = GST_VIDEO_FORMAT_YV12;
   } else if (hal_format == constants.OMX_COLOR_FormatYUV422SemiPlanar) {
     dev->viewfinder_format = GST_VIDEO_FORMAT_NV16;
   } else if (hal_format == constants.OMX_COLOR_FormatYUV420SemiPlanar) {
@@ -576,6 +576,7 @@ gst_droidcamsrc_dev_open (GstDroidCamSrcDev * dev, GstDroidCamSrcCamInfo * info)
   } else if (hal_format == constants.OMX_COLOR_Format16bitRGB565) {
     dev->viewfinder_format = GST_VIDEO_FORMAT_RGB16;
   } else {
+    GST_WARNING_OBJECT (src, "Unknown HAL color format 0x%x", hal_format);
     dev->viewfinder_format = GST_VIDEO_FORMAT_ENCODED;
   }
 

--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -826,9 +826,14 @@ gst_droidvdec_configure_state (GstVideoDecoder * decoder, guint width,
       dec->h_align = formats[format_index].h_align;
       dec->v_align = formats[format_index].v_align;
     } else {
-      GST_INFO_OBJECT (dec, "The HAL codec format %d is unrecognized",
+      GST_INFO_OBJECT (dec, "The HAL codec format 0x%x is unrecognized",
           md.hal_format);
-      dec->format = GST_VIDEO_FORMAT_ENCODED;
+      /* This should be GST_VIDEO_FORMAT_ENCODED but the videoconv? element
+         can't do passthrough of that format. Since the format can't be
+         identified the reported size of the buffer will be zero and it
+         won't be possible to map it so reporting the wrong format should
+         be harmless. */
+      dec->format = GST_VIDEO_FORMAT_YV12;
       dec->bytes_per_pixel = 0;
       dec->h_align = 0;
       dec->v_align = 0;
@@ -849,7 +854,7 @@ gst_droidvdec_configure_state (GstVideoDecoder * decoder, guint width,
       height = rect.bottom - rect.top;
     } else {
       GST_ELEMENT_ERROR (dec, STREAM, FORMAT, (NULL),
-          ("HAL codec format %d is unsupported", md.hal_format));
+          ("HAL codec format 0x%x is unsupported", md.hal_format));
       goto error;
     }
   }


### PR DESCRIPTION
This doesn't marry up with the same mapping in the video decoder
but that might be a translation error further up the line as the
camera HAL doesn't specify OMX formats itself.