### PR TITLE
[droidcamsrc] implement camerabin2's preview-image interface

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
  * Copyright (C) 2015-2016 Jolla LTD.
+ * Copyright (C) 2010 Texas Instruments, Inc
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -117,6 +118,7 @@ static guint droidcamsrc_signals[LAST_SIGNAL];
 #define DEFAULT_SENSOR_ORIENTATION     0
 #define DEFAULT_IMAGE_MODE             GST_DROIDCAMSRC_IMAGE_MODE_NORMAL
 #define DEFAULT_TARGET_BITRATE         12000000
+#define DEFAULT_POST_PREVIEW           FALSE
 
 static GstDroidCamSrcPad *
 gst_droidcamsrc_create_pad (GstDroidCamSrc * src,
@@ -206,6 +208,11 @@ gst_droidcamsrc_init (GstDroidCamSrc * src)
   src->image = gst_droidcamsrc_mode_new_image (src);
   src->video = gst_droidcamsrc_mode_new_video (src);
   src->active_mode = NULL;
+
+  src->post_preview = DEFAULT_POST_PREVIEW;
+  src->preview_caps = NULL;
+  src->preview_pipeline =
+      gst_camerabin_create_preview_pipeline (GST_ELEMENT_CAST (src), NULL);
 
   GST_OBJECT_FLAG_SET (src, GST_ELEMENT_FLAG_SOURCE);
 }
@@ -308,6 +315,15 @@ gst_droidcamsrc_get_property (GObject * object, guint prop_id, GValue * value,
       g_value_set_int (value, src->target_bitrate);
       break;
 
+    case PROP_POST_PREVIEW:
+      g_value_set_boolean (value, src->post_preview);
+      break;
+
+    case PROP_PREVIEW_CAPS:
+      if (src->preview_caps)
+        gst_value_set_caps (value, src->preview_caps);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -406,6 +422,42 @@ gst_droidcamsrc_set_property (GObject * object, guint prop_id,
       src->target_bitrate = g_value_get_int (value);
       break;
 
+    case PROP_POST_PREVIEW:
+      src->post_preview = g_value_get_boolean (value);
+
+      if (src->dev) {
+        gst_droidcamsrc_dev_update_preview_callback_flag (src->dev);
+      }
+
+      break;
+
+    case PROP_PREVIEW_CAPS:{
+      GstCaps *new_caps;
+
+      new_caps = (GstCaps *) gst_value_get_caps (value);
+      if (new_caps == NULL) {
+        new_caps = gst_caps_new_any ();
+      } else {
+        new_caps = gst_caps_ref (new_caps);
+      }
+
+      if (!gst_caps_is_equal (src->preview_caps, new_caps)) {
+        gst_caps_replace (&src->preview_caps, new_caps);
+
+        if (src->preview_pipeline) {
+          GST_DEBUG_OBJECT (src,
+              "Setting preview pipeline caps %" GST_PTR_FORMAT,
+              src->preview_caps);
+          gst_camerabin_preview_set_caps (src->preview_pipeline,
+              src->preview_caps);
+        }
+      } else {
+        GST_DEBUG_OBJECT (src, "New preview caps equal current preview caps");
+      }
+      gst_caps_unref (new_caps);
+    }
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -435,6 +487,15 @@ gst_droidcamsrc_finalize (GObject * object)
   gst_droidcamsrc_quirks_destroy (src->quirks);
 
   g_rec_mutex_clear (&src->dev_lock);
+
+  if (src->preview_pipeline) {
+    gst_camerabin_destroy_preview_pipeline (src->preview_pipeline);
+    src->preview_pipeline = NULL;
+  }
+
+  if (src->preview_caps) {
+    gst_caps_replace (&src->preview_caps, NULL);
+  }
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -520,6 +581,19 @@ gst_droidcamsrc_change_state (GstElement * element, GstStateChange transition)
         break;
       }
 
+      if (src->preview_pipeline == NULL) {
+        /* failed to create preview pipeline, fail state change */
+        ret = GST_STATE_CHANGE_FAILURE;
+      }
+
+      if (src->preview_caps) {
+        GST_DEBUG_OBJECT (src,
+            "Setting preview pipeline caps %" GST_PTR_FORMAT,
+            src->preview_caps);
+        gst_camerabin_preview_set_caps (src->preview_pipeline,
+            src->preview_caps);
+      }
+
       src->dev =
           gst_droidcamsrc_dev_new (src->vfsrc, src->imgsrc,
           src->vidsrc, &src->dev_lock);
@@ -582,6 +656,11 @@ gst_droidcamsrc_change_state (GstElement * element, GstStateChange transition)
 
       /* Now add the needed orientation tag */
       gst_droidcamsrc_add_vfsrc_orientation_tag (src);
+
+      /* without this the preview pipeline will not post buffer
+       * messages on the pipeline */
+      gst_element_set_state (src->preview_pipeline->pipeline,
+          GST_STATE_PLAYING);
     }
 
       break;
@@ -654,6 +733,8 @@ gst_droidcamsrc_change_state (GstElement * element, GstStateChange transition)
     case GST_STATE_CHANGE_PAUSED_TO_READY:
       gst_droidcamsrc_dev_deinit (src->dev);
       gst_droidcamsrc_dev_close (src->dev);
+
+      gst_element_set_state (src->preview_pipeline->pipeline, GST_STATE_READY);
       break;
 
     case GST_STATE_CHANGE_READY_TO_NULL:
@@ -662,6 +743,8 @@ gst_droidcamsrc_change_state (GstElement * element, GstStateChange transition)
 
       g_free (src->info);
       src->info = NULL;
+
+      gst_element_set_state (src->preview_pipeline->pipeline, GST_STATE_NULL);
       break;
 
     default:
@@ -1073,6 +1156,17 @@ gst_droidcamsrc_class_init (GstDroidCamSrcClass * klass)
       g_param_spec_variant ("supported-iso-speeds", "Supported ISO speeds",
           "Supported ISO speeds", G_VARIANT_TYPE_VARIANT, NULL,
           G_PARAM_READABLE));
+
+  /* camerabin interface */
+  g_object_class_install_property (gobject_class, PROP_POST_PREVIEW,
+      g_param_spec_boolean ("post-previews", "Post Previews",
+          "If capture preview images should be posted to the bus",
+          DEFAULT_POST_PREVIEW, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_PREVIEW_CAPS,
+      g_param_spec_boxed ("preview-caps", "Preview caps",
+          "The caps of the preview image to be posted (NULL means ANY)",
+          GST_TYPE_CAPS, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   gst_droidcamsrc_photography_add_overrides (gobject_class);
 
@@ -2475,4 +2569,15 @@ gst_droidcamsrc_get_video_caps_locked (GstDroidCamSrc * src)
   GST_DEBUG_OBJECT (src, "video caps %" GST_PTR_FORMAT, caps);
 
   return caps;
+}
+
+void
+gst_droidcamsrc_post_preview (GstDroidCamSrc * src, GstSample * sample)
+{
+  if (src->post_preview) {
+    gst_camerabin_preview_pipeline_post (src->preview_pipeline, sample);
+  } else {
+    GST_DEBUG_OBJECT (src, "Previews not enabled, not posting");
+    gst_sample_unref (sample);
+  }
 }

--- a/gst/droidcamsrc/gstdroidcamsrc.h
+++ b/gst/droidcamsrc/gstdroidcamsrc.h
@@ -125,6 +125,7 @@ struct _GstDroidCamSrc
   /* camerabin interface */
   gboolean post_preview;
   GstCaps *preview_caps;
+  GstElement *preview_filter;
   GstCameraBinPreviewPipelineData *preview_pipeline;
 
   /* protected with OBJECT_LOCK */

--- a/gst/droidcamsrc/gstdroidcamsrc.h
+++ b/gst/droidcamsrc/gstdroidcamsrc.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
  * Copyright (C) 2016 Jolla LTD.
+ * Copyright (C) 2010 Texas Instruments, Inc
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -121,6 +122,11 @@ struct _GstDroidCamSrc
 
   gint32 target_bitrate;
 
+  /* camerabin interface */
+  gboolean post_preview;
+  GstCaps *preview_caps;
+  GstCameraBinPreviewPipelineData *preview_pipeline;
+
   /* protected with OBJECT_LOCK */
   gint width;
   gint height;
@@ -145,6 +151,8 @@ void gst_droidcamsrc_timestamp (GstDroidCamSrc * src, GstBuffer * buffer);
 gboolean gst_droidcamsrc_apply_params (GstDroidCamSrc * src);
 void gst_droidcamsrc_apply_mode_settings (GstDroidCamSrc * src, GstDroidCamSrcApplyType type);
 void gst_droidcamsrc_update_max_zoom (GstDroidCamSrc * src);
+
+void gst_droidcamsrc_post_preview (GstDroidCamSrc * src, GstSample * sample);
 
 G_END_DECLS
 

--- a/gst/droidcamsrc/gstdroidcamsrcdev.h
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
  * Copyright (C) 2015-2016 Jolla LTD.
+ * Copyright (C) 2020 UBports Foundation.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -56,6 +57,10 @@ struct _GstDroidCamSrcDev
   DroidMediaCameraConstants c;
   GstVideoFormat viewfinder_format;
 
+  GstBuffer *last_preview_buffer;
+  GMutex last_preview_buffer_lock;
+  GCond last_preview_buffer_cond;
+
   gboolean use_recorder;
   GstDroidCamSrcRecorder *recorder;
 };
@@ -94,6 +99,8 @@ void gst_droidcamsrc_dev_send_command (GstDroidCamSrcDev * dev, gint cmd, gint a
 gboolean gst_droidcamsrc_dev_is_running (GstDroidCamSrcDev * dev);
 
 void gst_droidcamsrc_dev_queue_video_buffer (GstDroidCamSrcDev * dev, GstBuffer * buffer);
+
+void gst_droidcamsrc_dev_update_preview_callback_flag (GstDroidCamSrcDev * dev);
 
 G_END_DECLS
 

--- a/gst/droidcamsrc/gstdroidcamsrcphotography.h
+++ b/gst/droidcamsrc/gstdroidcamsrcphotography.h
@@ -81,7 +81,8 @@ typedef enum
 
   /* camerabin interface */
   PROP_POST_PREVIEW,
-  PROP_PREVIEW_CAPS
+  PROP_PREVIEW_CAPS,
+  PROP_PREVIEW_FILTER
 } GstDroidCamSrcProperties;
 
 void gst_droidcamsrc_photography_register (gpointer g_iface,  gpointer iface_data);

--- a/gst/droidcamsrc/gstdroidcamsrcphotography.h
+++ b/gst/droidcamsrc/gstdroidcamsrcphotography.h
@@ -77,7 +77,11 @@ typedef enum
   PROP_MIN_EXPOSURE_TIME,
   PROP_MAX_EXPOSURE_TIME,
   PROP_NOISE_REDUCTION,
-  PROP_EXPOSURE_MODE
+  PROP_EXPOSURE_MODE,
+
+  /* camerabin interface */
+  PROP_POST_PREVIEW,
+  PROP_PREVIEW_CAPS
 } GstDroidCamSrcProperties;
 
 void gst_droidcamsrc_photography_register (gpointer g_iface,  gpointer iface_data);


### PR DESCRIPTION
This patch implement camerabin2's preview-image interface,
which make the element post a preview-image bus message when
post-previews property is enabled.

As Android doesn't seem to have the concept of preview-image (there are
raw & postview callbacks but they seem not to be called), I replicate
what Qt does with it's native Android plugin, which is storing the
latest viewfinder frame and using that as the preview. This require
changing how the preview callback flags is calculated as otherwise
preview callback won't be called. The last preview buffer is kept
within the structure of dev but use the seperated lock and condition
variable, as the buffer is updated in the callback called from Android
side.

Camerabin2's preview-image interface also require that the element has
the preview-caps property and must send the preview-image according to
this caps. To fulfill that, a camerabinpipeline is constructed inside
the gstdroidcamsrc element. This pipeline will take care of all
conversion required to make the preview image comply to the provided
caps and will also actually posting it to the bus.

When the image capture is requested, the post-preview property is
copied to image capturing structure so that the change after the
capture won't affect this capture. When the shutter callback is
called and if the preview image is requested, the kept viewfinder
buffer is sent to the preview pipeline for processing & posting. For
video recording, preview is posted when the recording is requested.

This can remove the requirement to patch QtMultimedia not to set the
post-preview flag, and improve the correctness of the element outside
of Mer and Sailfish OS.