### PR TITLE
[droidcamsrc] call droid_media_camera_take_picture from another thread

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrcdev.h
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.h
@@ -63,6 +63,8 @@ struct _GstDroidCamSrcDev
 
   gboolean use_recorder;
   GstDroidCamSrcRecorder *recorder;
+
+  GstTaskPool *task_pool;
 };
 
 GstDroidCamSrcDev *gst_droidcamsrc_dev_new (GstDroidCamSrcPad *vfsrc,


### PR DESCRIPTION
take_picture call in HAL sometimes need to read information from preview
frames for e.g. auto exposure when using flash. If the calling thread
also handles pulling preview frames, this will create a deadlock.

To prevent this, I've moved the actual droid_media_camera_take_picture()
call to a function that will be called in a background thread. The
GstTaskPool is used to execute the function in the glib's thread pool,
so that the new thread doesn't have to be created every time.

This fixed taking a picture with the flash on on Fairphone 2 with
Halium 7.1-based port and Ubuntu Touch.
