### PR TITLE
Video: Fix colour display on video playback using software codecs.

### DIFF
--- a/gst/droideglsink/gstdroideglsink.c
+++ b/gst/droideglsink/gstdroideglsink.c
@@ -46,7 +46,7 @@ static GstStaticPadTemplate gst_droideglsink_sink_template_factory =
     GST_STATIC_CAPS (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
         (GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_BUFFER,
             GST_DROID_MEDIA_BUFFER_MEMORY_VIDEO_FORMATS) "; "
-        GST_VIDEO_CAPS_MAKE ("{YV12, NV21}")));
+        GST_VIDEO_CAPS_MAKE ("{RGBA, RGBx, RGB, RGB12, BGRA}")));
 
 enum
 {


### PR DESCRIPTION
The previous YV12 and other formats are not supported as public formats in android.graphics.PixelFormat.isPublicFormat(), so should be considered internal formats.

Requires https://github.com/sailfishos/droidmedia/pull/57 to properly transfer RGB formats to a droidmediabuffer for display.