### PR TITLE
video: Propose native buffers to avoid having to copy GstBuffers.

### DIFF
--- a/gst-libs/gst/droid/gstdroidbufferpool.h
+++ b/gst-libs/gst/droid/gstdroidbufferpool.h
@@ -23,6 +23,7 @@
 #define __GST_DROID_BUFFER_POOL_H__
 
 #include <gst/gstbufferpool.h>
+#include <gst/video/video-info.h>
 
 G_BEGIN_DECLS
 
@@ -40,6 +41,8 @@ struct _GstDroidBufferPool
   GMutex lock;
   GCond cond;
   gint num_buffers;
+  GstAllocator *allocator;
+  GstVideoInfo video_info;
 };
 
 struct _GstDroidBufferPoolClass

--- a/gst-libs/gst/droid/gstdroidmediabuffer.h
+++ b/gst-libs/gst/droid/gstdroidmediabuffer.h
@@ -36,10 +36,8 @@ GstAllocator * gst_droid_media_buffer_allocator_new (void);
 GstMemory    * gst_droid_media_buffer_allocator_alloc (GstAllocator * allocator,
                                                        DroidMediaBufferQueue *queue,
 						       DroidMediaBufferCallbacks *cb);
-GstMemory    * gst_droid_media_buffer_allocator_alloc_from_data (GstAllocator * allocator,
-								 GstVideoInfo * info,
-								 DroidMediaData * data,
-								 DroidMediaBufferCallbacks *cb);
+GstMemory    * gst_droid_media_buffer_allocator_alloc_new (GstAllocator * allocator,
+                GstVideoInfo * info, GstBuffer * buffer);
 
 DroidMediaBuffer * gst_droid_media_buffer_memory_get_buffer (GstMemory * mem);
 gboolean       gst_is_droid_media_buffer_memory (GstMemory * mem);


### PR DESCRIPTION
[video] Propose native buffers to avoid having to copy GstBuffers. JB#47801

Android YV12 planes are aligned to 16 pixels, with the U and V planes aligned separately.
https://developer.android.com/reference/android/graphics/ImageFormat.html#YV12