### PR TITLE
[gst-droid] Use the buffer pool proposed by droideglsink in camera and video decoder. Contributes to JB#49340

### DIFF
--- a/gst-libs/gst/droid/Makefile.am
+++ b/gst-libs/gst/droid/Makefile.am
@@ -5,9 +5,13 @@ libgstdroid_@GST_API_VERSION@_ladir = $(libdir)
 libgstdroid_@GST_API_VERSION@_la_includedir = \
 	$(includedir)/gstreamer-@GST_API_VERSION@/gst/allocators
 
-libgstdroid_@GST_API_VERSION@_la_CFLAGS = $(GST_CFLAGS) -I/usr/include/droidmedia/
+libgstdroid_@GST_API_VERSION@_la_CFLAGS = $(GST_CFLAGS) \
+					  $(EGL_CFLAGS) \
+					 -DEGL_NO_X11 \	
+					 -I/usr/include/droidmedia/
 
-libgstdroid_@GST_API_VERSION@_la_LIBADD = $(GST_LIBS)
+libgstdroid_@GST_API_VERSION@_la_LIBADD = $(GST_LIBS) \
+					  $(EGL_LIBS)
 
 noinst_HEADERS =
 

--- a/gst-libs/gst/droid/gstdroidbufferpool.c
+++ b/gst-libs/gst/droid/gstdroidbufferpool.c
@@ -23,28 +23,16 @@
 #include "gstdroidbufferpool.h"
 #include "gstdroidmediabuffer.h"
 
+/* Element signals and args */
+enum
+{
+  BUFFERS_INVALIDATED,
+  LAST_SIGNAL
+};
 #define gst_droid_buffer_pool_parent_class parent_class
 G_DEFINE_TYPE (GstDroidBufferPool, gst_droid_buffer_pool, GST_TYPE_BUFFER_POOL);
 
-static void
-gst_droid_buffer_pool_reset_buffer (GstBufferPool * pool, GstBuffer * buffer)
-{
-  GstDroidBufferPool *dpool = GST_DROID_BUFFER_POOL (pool);
-
-  // if the allocator is set then we should keep the memory
-  if (!dpool->allocator) {
-    gst_buffer_remove_all_memory (buffer);
-    GST_BUFFER_FLAG_UNSET (buffer, GST_BUFFER_FLAG_TAG_MEMORY);
-  }
-
-  g_mutex_lock (&dpool->lock);
-  ++dpool->num_buffers;
-  GST_DEBUG_OBJECT (dpool, "num buffers: %d", dpool->num_buffers);
-  g_cond_signal (&dpool->cond);
-  g_mutex_unlock (&dpool->lock);
-
-  return GST_BUFFER_POOL_CLASS (parent_class)->reset_buffer (pool, buffer);
-}
+static guint gst_droid_buffer_pool_signals[LAST_SIGNAL] = { 0 };
 
 static gboolean
 gst_droid_buffer_pool_set_config (GstBufferPool * bpool, GstStructure * config)
@@ -60,6 +48,8 @@ gst_droid_buffer_pool_set_config (GstBufferPool * bpool, GstStructure * config)
   }
   // If we have caps then we can create droid buffers
   if (caps != NULL) {
+    GstCapsFeatures *features = gst_caps_get_features (caps, 0);
+
     GST_OBJECT_LOCK (pool);
 
     if (!gst_video_info_from_caps (&pool->video_info, caps)) {
@@ -69,6 +59,8 @@ gst_droid_buffer_pool_set_config (GstBufferPool * bpool, GstStructure * config)
     }
 
     pool->video_info.size = size;
+    pool->use_queue_buffers = gst_caps_features_contains
+        (features, GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER);
 
     GST_DEBUG_OBJECT (pool, "Configured pool. caps: %" GST_PTR_FORMAT, caps);
     pool->allocator = gst_droid_media_buffer_allocator_new ();
@@ -98,97 +90,222 @@ gst_droid_buffer_pool_alloc (GstBufferPool * pool, GstBuffer ** buf,
   GstBuffer *buffer;
   GstMemory *memory;
 
+  if (!dpool->allocator) {
+    return GST_FLOW_ERROR;
+  }
+
   buffer = gst_buffer_new ();
   if (!buffer) {
     return GST_FLOW_ERROR;
   }
-  // if the allocator is set then we should create the memory too
-  if (dpool->allocator) {
+
+  if (!dpool->use_queue_buffers) {
     memory = gst_droid_media_buffer_allocator_alloc_new (dpool->allocator,
-        &dpool->video_info, buffer);
+        &dpool->video_info);
     if (!memory) {
+      gst_buffer_unref (buffer);
       return GST_FLOW_ERROR;
     }
+
+    gst_buffer_insert_memory (buffer, 0, memory);
   }
 
-  g_mutex_lock (&dpool->lock);
-  ++dpool->num_buffers;
   *buf = buffer;
-  GST_DEBUG_OBJECT (dpool, "num buffers: %d", dpool->num_buffers);
-  g_cond_signal (&dpool->cond);
-  g_mutex_unlock (&dpool->lock);
 
   return GST_FLOW_OK;
 }
 
-gboolean
-gst_droid_buffer_pool_wait_for_buffer (GstBufferPool * pool)
+static void
+gst_droid_buffer_release_buffer (GstBufferPool * pool, GstBuffer * buffer)
+{
+  GstDroidBufferPool *dpool = GST_DROID_BUFFER_POOL (pool);
+  DroidMediaBuffer *droid_buffer = NULL;
+
+  if (dpool->use_queue_buffers) {
+    guint index;
+
+    g_mutex_lock (&dpool->binding_lock);
+
+    if (g_ptr_array_find (dpool->acquired_buffers, buffer, &index)) {
+      g_ptr_array_remove_index_fast (dpool->acquired_buffers, index);
+
+      droid_buffer =
+          gst_droid_media_buffer_memory_get_buffer_from_gst_buffer (buffer);
+
+      if (droid_media_buffer_get_user_data (droid_buffer) == buffer) {
+        g_ptr_array_add (dpool->bound_buffers, buffer);
+      } else {
+        droid_buffer = NULL;
+      }
+    }
+
+    g_mutex_unlock (&dpool->binding_lock);
+  }
+
+  if (droid_buffer) {
+    buffer->pool = gst_object_ref (pool);
+
+    droid_media_buffer_release (droid_buffer, dpool->display, NULL);
+  } else {
+    if (dpool->use_queue_buffers) {
+      gst_buffer_remove_all_memory (buffer);
+      GST_BUFFER_FLAG_UNSET (buffer, GST_BUFFER_FLAG_TAG_MEMORY);
+    }
+
+    GST_BUFFER_POOL_CLASS (parent_class)->release_buffer (pool, buffer);
+  }
+}
+
+void
+gst_droid_buffer_pool_set_egl_display (GstBufferPool * pool, EGLDisplay display)
 {
   GstDroidBufferPool *dpool = GST_DROID_BUFFER_POOL (pool);
 
-  if (GST_BUFFER_POOL_IS_FLUSHING (pool)) {
+  if (dpool) {
+    dpool->display = display;
+  }
+}
+
+gboolean
+gst_droid_buffer_pool_bind_media_buffer (GstBufferPool * pool,
+    DroidMediaBuffer * buffer)
+{
+  GstDroidBufferPool *dpool;
+  GstBuffer *gst_buffer;
+  GstMemory *mem;
+
+  if (!GST_IS_DROID_BUFFER_POOL (pool)) {
     return FALSE;
   }
 
-  g_mutex_lock (&dpool->lock);
-
-  if (dpool->num_buffers > 0) {
-    g_mutex_unlock (&dpool->lock);
-    return TRUE;
-  }
-
-  g_cond_wait (&dpool->cond, &dpool->lock);
-  g_mutex_unlock (&dpool->lock);
-
-  if (GST_BUFFER_POOL_IS_FLUSHING (pool)) {
+  if (gst_buffer_pool_acquire_buffer (pool, &gst_buffer, NULL) != GST_FLOW_OK) {
     return FALSE;
   }
+
+  dpool = GST_DROID_BUFFER_POOL (pool);
+
+  mem =
+      gst_droid_media_buffer_allocator_alloc_from_buffer (dpool->allocator,
+      buffer);
+
+  if (!mem) {
+    gst_buffer_unref (gst_buffer);
+
+    return FALSE;
+  }
+
+  gst_buffer_insert_memory (gst_buffer, 0, mem);
+
+  g_mutex_lock (&dpool->binding_lock);
+
+  droid_media_buffer_set_user_data (buffer, gst_buffer);
+
+  g_ptr_array_add (dpool->bound_buffers, gst_buffer);
+
+  g_mutex_unlock (&dpool->binding_lock);
 
   return TRUE;
 }
 
 static void
-gst_droid_buffer_pool_flush_start (GstBufferPool * pool)
+gst_droid_buffer_pool_clear_buffers_user_data (GPtrArray * buffers)
 {
-  GstDroidBufferPool *dpool = GST_DROID_BUFFER_POOL (pool);
+  guint i;
 
-  g_mutex_lock (&dpool->lock);
-  g_cond_signal (&dpool->cond);
-  g_mutex_unlock (&dpool->lock);
+  for (i = 0; i < buffers->len; ++i) {
+    DroidMediaBuffer *buffer =
+        gst_droid_media_buffer_memory_get_buffer_from_gst_buffer ((GstBuffer *)
+        g_ptr_array_index (buffers, i));
+
+    if (buffer) {
+      droid_media_buffer_set_user_data (buffer, NULL);
+    }
+  }
 }
 
-static GstFlowReturn
-gst_droid_buffer_pool_acquire_buffer (GstBufferPool * pool, GstBuffer ** buffer,
-    GstBufferPoolAcquireParams * params)
+GstBuffer *
+gst_droid_buffer_pool_acquire_media_buffer (GstBufferPool * pool,
+    DroidMediaBuffer * buffer)
 {
+  guint index;
+  GstBuffer *gst_buffer = NULL;
   GstDroidBufferPool *dpool = GST_DROID_BUFFER_POOL (pool);
-  GstFlowReturn ret;
 
-  ret =
-      GST_BUFFER_POOL_CLASS (parent_class)->acquire_buffer (pool, buffer,
-      params);
-
-  if (G_LIKELY (ret == GST_FLOW_OK)) {
-    g_mutex_lock (&dpool->lock);
-    --dpool->num_buffers;
-    GST_DEBUG_OBJECT (dpool, "num buffers: %d", dpool->num_buffers);
-    g_mutex_unlock (&dpool->lock);
+  if (!dpool) {
+    return NULL;
   }
 
-  return ret;
+  g_mutex_lock (&dpool->binding_lock);
+
+  gst_buffer = (GstBuffer *) droid_media_buffer_get_user_data (buffer);
+
+  if (gst_buffer->pool != pool) {
+    droid_media_buffer_set_user_data (buffer, NULL);
+
+    g_mutex_unlock (&dpool->binding_lock);
+
+    if (!gst_droid_buffer_pool_bind_media_buffer (pool, buffer)) {
+      return NULL;
+    }
+
+    if (gst_buffer) {
+      gst_buffer_unref (gst_buffer);
+    }
+
+    g_mutex_lock (&dpool->binding_lock);
+
+    gst_buffer = (GstBuffer *) droid_media_buffer_get_user_data (buffer);
+  }
+
+  if (gst_buffer && g_ptr_array_find (dpool->bound_buffers, gst_buffer, &index)) {
+    g_ptr_array_remove_index_fast (dpool->bound_buffers, index);
+
+    g_ptr_array_add (dpool->acquired_buffers, gst_buffer);
+  }
+
+  g_mutex_unlock (&dpool->binding_lock);
+
+  return gst_buffer;
 }
 
-static gboolean
-gst_droid_buffer_pool_start (GstBufferPool * pool)
+void
+gst_droid_buffer_pool_media_buffers_invalidated (GstBufferPool * pool)
 {
-  GstDroidBufferPool *dpool = GST_DROID_BUFFER_POOL (pool);
+  GPtrArray *buffers_to_release = NULL;
+  guint i;
+  GstDroidBufferPool *dpool;
 
-  g_mutex_lock (&dpool->lock);
-  dpool->num_buffers = 0;
-  GST_DEBUG_OBJECT (dpool, "num buffers: %d", dpool->num_buffers);
-  g_mutex_unlock (&dpool->lock);
+  if (!pool || !GST_IS_DROID_BUFFER_POOL (pool)) {
+    GST_WARNING_OBJECT (pool, "Pool is not a GstDroidBufferPool");
+    return;
+  }
 
-  return GST_BUFFER_POOL_CLASS (parent_class)->start (pool);
+  dpool = GST_DROID_BUFFER_POOL (pool);
+
+  g_mutex_lock (&dpool->binding_lock);
+
+  gst_droid_buffer_pool_clear_buffers_user_data (dpool->bound_buffers);
+  gst_droid_buffer_pool_clear_buffers_user_data (dpool->acquired_buffers);
+
+  if (dpool->bound_buffers->len != 0) {
+    buffers_to_release = dpool->bound_buffers;
+
+    dpool->bound_buffers = g_ptr_array_new ();
+  }
+
+  g_ptr_array_set_size (dpool->acquired_buffers, 0);
+
+  g_mutex_unlock (&dpool->binding_lock);
+
+  if (buffers_to_release) {
+    for (i = 0; i < buffers_to_release->len; ++i) {
+      gst_buffer_unref ((GstBuffer *) g_ptr_array_index (buffers_to_release,
+              i));
+    }
+    g_ptr_array_free (buffers_to_release, TRUE);
+  }
+
+  g_signal_emit (pool, gst_droid_buffer_pool_signals[BUFFERS_INVALIDATED], 0);
 }
 
 static void
@@ -199,8 +316,11 @@ gst_droid_buffer_pool_finalize (GObject * object)
     gst_object_unref (pool->allocator);
     pool->allocator = 0;
   }
-  g_mutex_clear (&pool->lock);
-  g_cond_clear (&pool->cond);
+
+  g_ptr_array_free (pool->bound_buffers, TRUE);
+  g_ptr_array_free (pool->acquired_buffers, TRUE);
+
+  g_mutex_clear (&pool->binding_lock);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -212,13 +332,16 @@ gst_droid_buffer_pool_class_init (GstDroidBufferPoolClass * klass G_GNUC_UNUSED)
   GstBufferPoolClass *gstbufferpool_class = (GstBufferPoolClass *) klass;
 
   gobject_class->finalize = gst_droid_buffer_pool_finalize;
-  gstbufferpool_class->start = gst_droid_buffer_pool_start;
-  gstbufferpool_class->acquire_buffer = gst_droid_buffer_pool_acquire_buffer;
-  gstbufferpool_class->reset_buffer = gst_droid_buffer_pool_reset_buffer;
   gstbufferpool_class->alloc_buffer = gst_droid_buffer_pool_alloc;
-  gstbufferpool_class->flush_start = gst_droid_buffer_pool_flush_start;
+  gstbufferpool_class->release_buffer = gst_droid_buffer_release_buffer;
   gstbufferpool_class->get_options = gst_droid_buffer_pool_get_options;
   gstbufferpool_class->set_config = gst_droid_buffer_pool_set_config;
+
+  gst_droid_buffer_pool_signals[BUFFERS_INVALIDATED] =
+      g_signal_new ("buffers-invalidated",
+      G_TYPE_FROM_CLASS (gstbufferpool_class), G_SIGNAL_RUN_LAST,
+      G_STRUCT_OFFSET (GstDroidBufferPoolClass, signal_buffers_invalidated),
+      NULL, NULL, g_cclosure_marshal_generic, G_TYPE_NONE, 0);
 }
 
 static void
@@ -226,8 +349,13 @@ gst_droid_buffer_pool_init (GstDroidBufferPool * object)
 {
   GstDroidBufferPool *pool = GST_DROID_BUFFER_POOL (object);
   pool->allocator = 0;
-  g_mutex_init (&pool->lock);
-  g_cond_init (&pool->cond);
+
+  g_mutex_init (&pool->binding_lock);
+
+  pool->bound_buffers = g_ptr_array_new ();
+  pool->acquired_buffers = g_ptr_array_new ();
+  pool->use_queue_buffers = FALSE;
+  pool->display = NULL;
 }
 
 GstBufferPool *

--- a/gst-libs/gst/droid/gstdroidmediabuffer.h
+++ b/gst-libs/gst/droid/gstdroidmediabuffer.h
@@ -29,20 +29,22 @@ G_BEGIN_DECLS
 
 #define GST_ALLOCATOR_DROID_MEDIA_BUFFER                    "droidmediabuffer"
 #define GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_BUFFER          "memory:DroidMediaBuffer"
+#define GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER          "memory:DroidMediaQueueBuffer"
 #define GST_DROID_MEDIA_BUFFER_MEMORY_VIDEO_FORMATS "{ NV12_64Z32, YV12, NV16, " \
     "NV12, NV21, YUY2, RGBA, RGBx, RGB, RGB16, BGRA, ENCODED }"
 
 GstAllocator * gst_droid_media_buffer_allocator_new (void);
-GstMemory    * gst_droid_media_buffer_allocator_alloc (GstAllocator * allocator,
-                                                       DroidMediaBufferQueue *queue,
-						       DroidMediaBufferCallbacks *cb);
 GstMemory    * gst_droid_media_buffer_allocator_alloc_new (GstAllocator * allocator,
-                GstVideoInfo * info, GstBuffer * buffer);
+                                                           GstVideoInfo * info);
+GstMemory    * gst_droid_media_buffer_allocator_alloc_from_buffer (GstAllocator * allocator,
+                                                                   DroidMediaBuffer * buffer);
 
 DroidMediaBuffer * gst_droid_media_buffer_memory_get_buffer (GstMemory * mem);
+DroidMediaBuffer * gst_droid_media_buffer_memory_get_buffer_from_gst_buffer (GstBuffer *buffer);
 gboolean       gst_is_droid_media_buffer_memory (GstMemory * mem);
 
 GstVideoInfo * gst_droid_media_buffer_get_video_info (GstMemory * mem);
+GstVideoInfo * gst_droid_media_buffer_get_video_info_from_gst_buffer (GstBuffer *buffer);
 
 G_END_DECLS
 

--- a/gst/Makefile.am
+++ b/gst/Makefile.am
@@ -6,6 +6,7 @@ plugin_LTLIBRARIES = libgstdroid.la
 
 libgstdroid_la_CFLAGS = $(GST_CFLAGS) $(NGI_CFLAGS) $(EGL_CFLAGS) \
                         $(NGM_CFLAGS)\
+			-DEGL_NO_X11 \
 	                -I$(top_builddir)/gst-libs/ \
 			-I/usr/include/droidmedia/ \
                         -Idroidcamsrc/ \

--- a/gst/droidcamsrc/Makefile.am
+++ b/gst/droidcamsrc/Makefile.am
@@ -2,6 +2,7 @@ AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\"
 noinst_LTLIBRARIES = libgstdroidcamsrc.la
 libgstdroidcamsrc_la_CFLAGS = $(GST_CFLAGS) $(NGI_CFLAGS) \
                               $(NGM_CFLAGS) $(EXIF_CFLAGS) \
+			      -DEGL_NO_X11 \
 			      -I$(top_builddir)/gst/ \
 			      -I$(top_builddir)/gst-libs/ \
 			      -I/usr/include/droidmedia/

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -126,7 +126,7 @@ gst_droidcamsrc_params_fill_fps_range_arrays_locked (GstDroidCamSrcParams *
     return;
   }
 
-  if (!range[0] == '(') {
+  if (range[0] != '(') {
     GST_ERROR ("invalid preview-fps-range-values");
     return;
   }
@@ -384,7 +384,7 @@ gst_droidcamsrc_params_get_viewfinder_caps (GstDroidCamSrcParams * params,
   caps =
       gst_caps_merge (gst_droidcamsrc_params_get_caps_locked (params,
           "preview-size-values", "video/x-raw",
-          GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_BUFFER,
+          GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER,
           gst_video_format_to_string (format)),
       gst_droidcamsrc_params_get_caps_locked (params, "preview-size-values",
           "video/x-raw", NULL, "NV21"));

--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -1143,7 +1143,9 @@ gst_droidvdec_finish (GstVideoDecoder * decoder)
   GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
   /* Now we wait for the codec to signal EOS */
   g_cond_wait (&dec->state_cond, &dec->state_lock);
+  g_mutex_unlock (&dec->state_lock);
   GST_VIDEO_DECODER_STREAM_LOCK (decoder);
+  g_mutex_lock (&dec->state_lock);
   GST_LOG_OBJECT (dec, "acquired stream lock");
 
   /* We drained the codec. Better to recreate it. */

--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -45,62 +45,62 @@ G_DEFINE_TYPE (GstDroidVDec, gst_droidvdec, GST_TYPE_VIDEO_DECODER);
 GST_DEBUG_CATEGORY_EXTERN (gst_droid_vdec_debug);
 #define GST_CAT_DEFAULT gst_droid_vdec_debug
 
-typedef struct
-{
-  int *hal_format;
-  GstVideoFormat gst_format;
-  GstDroidVideoConvertToI420 convert_to_i420;
-  gsize bytes_per_pixel;
-  gsize h_align;
-  gsize v_align;
+#define GST_DROIDVDEC_STATE_LOCK(decoder) \
+    g_mutex_lock (&(decoder)->state_lock)
 
-} GstDroidVideoFormatMap;
+#define GST_DROIDVDEC_STATE_UNLOCK(decoder)
+g_mutex_unlock (&(decoder)->state_lock)
 
-static GstStaticPadTemplate gst_droidvdec_src_template_factory =
-    GST_STATIC_PAD_TEMPLATE (GST_VIDEO_DECODER_SRC_NAME,
+     typedef struct
+     {
+       int *hal_format;
+       GstVideoFormat gst_format;
+       GstDroidVideoConvertToI420 convert_to_i420;
+       gsize bytes_per_pixel;
+       gsize h_align;
+       gsize v_align;
+
+     } GstDroidVideoFormatMap;
+
+     static GstStaticPadTemplate gst_droidvdec_src_template_factory =
+         GST_STATIC_PAD_TEMPLATE (GST_VIDEO_DECODER_SRC_NAME,
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
-        (GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_BUFFER,
+        (GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER,
             GST_DROID_MEDIA_BUFFER_MEMORY_VIDEO_FORMATS) ";"
         GST_VIDEO_CAPS_MAKE ("I420")));
 
-static gboolean gst_droidvdec_configure_state (GstVideoDecoder * decoder,
+     static gboolean gst_droidvdec_configure_state (GstVideoDecoder * decoder,
     guint width, guint height);
-static void gst_droidvdec_error (void *data, int err);
-static int gst_droidvdec_size_changed (void *data, int32_t width,
+     static void gst_droidvdec_error (void *data, int err);
+     static int gst_droidvdec_size_changed (void *data, int32_t width,
     int32_t height);
-static void gst_droidvdec_signal_eos (void *data);
-static void gst_droidvdec_buffers_released (void *user);
-static void gst_droidvdec_frame_available (void *user);
-static void gst_droidvdec_data_available (void *data,
+     static void gst_droidvdec_signal_eos (void *data);
+     static void gst_droidvdec_buffers_released (void *user);
+     static bool gst_droidvdec_buffer_created (void *user,
+    DroidMediaBuffer * buffer);
+     static bool gst_droidvdec_frame_available (void *user,
+    DroidMediaBuffer * buffer);
+     static void gst_droidvdec_data_available (void *data,
     DroidMediaCodecData * encoded);
-static gboolean gst_droidvdec_convert_buffer (GstDroidVDec * dec,
+     static gboolean gst_droidvdec_convert_buffer (GstDroidVDec * dec,
     GstBuffer * out, DroidMediaData * in, GstVideoInfo * info);
-static void gst_droidvdec_loop (GstDroidVDec * dec);
-static GstFlowReturn gst_droidvdec_finish_frame (GstVideoDecoder * decoder,
+     static void gst_droidvdec_loop (GstDroidVDec * dec);
+     static GstFlowReturn gst_droidvdec_finish_frame (GstVideoDecoder * decoder,
     GstVideoCodecFrame * frame);
 
-static void
-gst_droidvdec_loop (GstDroidVDec * dec)
+     static void gst_droidvdec_loop (GstDroidVDec * dec)
 {
   GST_LOG_OBJECT (dec, "loop");
 
-  if (!gst_droid_buffer_pool_wait_for_buffer (dec->pool)) {
-    goto out;
-  }
-
-  while (droid_media_codec_loop (dec->codec)
-      == DROID_MEDIA_CODEC_LOOP_OK) {
+  if (droid_media_codec_loop (dec->codec) == DROID_MEDIA_CODEC_LOOP_OK) {
     GST_LOG_OBJECT (dec, "tick");
-    return;
+  } else {
+    GST_INFO_OBJECT (dec, "pausing task");
+    gst_pad_pause_task (GST_VIDEO_DECODER_SRC_PAD (GST_VIDEO_DECODER (dec)));
   }
-
-out:
-  GST_INFO_OBJECT (dec, "pausing task");
-  gst_pad_pause_task (GST_VIDEO_DECODER_SRC_PAD (GST_VIDEO_DECODER (dec)));
 }
-
 
 static void
 gst_droidvec_copy_plane (guint8 * out, gint stride_out, guint8 * in,
@@ -278,37 +278,13 @@ static gboolean
 gst_droidvdec_create_codec (GstDroidVDec * dec, GstBuffer * input)
 {
   DroidMediaCodecDecoderMetaData md;
+  DroidMediaBufferQueue *queue;
   const gchar *droid = gst_droid_codec_get_droid_type (dec->codec_type);
 
   GST_INFO_OBJECT (dec, "create codec of type %s: %dx%d",
       droid, dec->in_state->info.width, dec->in_state->info.height);
 
   memset (&md, 0x0, sizeof (md));
-
-  /* Let's take care of the buffer pool first */
-  if (!dec->pool) {
-    GstStructure *config;
-
-    dec->pool = gst_droid_buffer_pool_new ();
-    config = gst_buffer_pool_get_config (dec->pool);
-    /* pass NULL for the caps. We don't have it yet */
-    gst_buffer_pool_config_set_params (config, NULL, 0,
-        GST_DROID_DEC_NUM_BUFFERS, GST_DROID_DEC_NUM_BUFFERS);
-
-    if (!gst_buffer_pool_set_config (dec->pool, config)) {
-      GST_ELEMENT_ERROR (dec, STREAM, FAILED, (NULL),
-          ("Failed to configure buffer pool"));
-      return FALSE;
-    }
-
-    if (!gst_buffer_pool_set_active (dec->pool, TRUE)) {
-      GST_ELEMENT_ERROR (dec, STREAM, FAILED, (NULL),
-          ("Failed to activate buffer pool"));
-      return FALSE;
-    }
-  } else {
-    gst_buffer_pool_set_flushing (dec->pool, FALSE);
-  }
 
   md.parent.type = droid;
   md.parent.width = dec->in_state->info.width;
@@ -350,7 +326,7 @@ gst_droidvdec_create_codec (GstDroidVDec * dec, GstBuffer * input)
     goto error;
   }
 
-  dec->queue = droid_media_codec_get_buffer_queue (dec->codec);
+  queue = droid_media_codec_get_buffer_queue (dec->codec);
 
   {
     DroidMediaCodecCallbacks cb;
@@ -360,11 +336,12 @@ gst_droidvdec_create_codec (GstDroidVDec * dec, GstBuffer * input)
     droid_media_codec_set_callbacks (dec->codec, &cb, dec);
   }
 
-  if (dec->queue) {
+  if (queue) {
     DroidMediaBufferQueueCallbacks cb;
     cb.buffers_released = gst_droidvdec_buffers_released;
+    cb.buffer_created = gst_droidvdec_buffer_created;
     cb.frame_available = gst_droidvdec_frame_available;
-    droid_media_buffer_queue_set_callbacks (dec->queue, &cb, dec);
+    droid_media_buffer_queue_set_callbacks (queue, &cb, dec);
   } else {
     DroidMediaCodecDataCallbacks cb;
     cb.data_available = gst_droidvdec_data_available;
@@ -377,7 +354,6 @@ gst_droidvdec_create_codec (GstDroidVDec * dec, GstBuffer * input)
 
     droid_media_codec_destroy (dec->codec);
     dec->codec = NULL;
-    dec->queue = NULL;
 
     goto error;
   }
@@ -391,14 +367,62 @@ gst_droidvdec_create_codec (GstDroidVDec * dec, GstBuffer * input)
   return TRUE;
 
 error:
-  gst_buffer_pool_set_active (dec->pool, FALSE);
   return FALSE;
 }
 
 static void
-gst_droidvdec_buffers_released (G_GNUC_UNUSED void *user)
+gst_droidvdec_buffers_released (void *user)
 {
-  GST_FIXME ("Not sure what to do here really");
+  GstVideoDecoder *dec = (GstVideoDecoder *) user;
+
+  GstBufferPool *pool = gst_video_decoder_get_buffer_pool (dec);
+
+  if (pool) {
+    gst_droid_buffer_pool_media_buffers_invalidated (pool);
+    gst_object_unref (pool);
+  }
+}
+
+static bool
+gst_droidvdec_buffer_created (void *user, DroidMediaBuffer * buffer)
+{
+  GstDroidVDec *dec = (GstDroidVDec *) user;
+  GstVideoDecoder *decoder = GST_VIDEO_DECODER (dec);
+  bool ret = false;
+  GstBufferPool *pool = NULL;
+
+  GST_VIDEO_DECODER_STREAM_LOCK (decoder);
+
+  if (dec->dirty) {
+    GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
+    return false;
+  }
+
+  /* Now we can configure the state */
+  if (G_UNLIKELY (!dec->out_state)) {
+    DroidMediaBufferInfo droid_info;
+
+    droid_media_buffer_get_info (buffer, &droid_info);
+
+    if (!gst_droidvdec_configure_state (decoder, droid_info.width,
+            droid_info.height)) {
+      dec->downstream_flow_ret = GST_FLOW_ERROR;
+      GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
+      return false;
+    }
+  }
+
+  pool = gst_video_decoder_get_buffer_pool (decoder);
+
+  GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
+
+  if (pool) {
+    ret = gst_droid_buffer_pool_bind_media_buffer (pool, buffer);
+
+    gst_object_unref (pool);
+  }
+
+  return ret;
 }
 
 static gboolean
@@ -437,78 +461,51 @@ gst_droidvdec_convert_buffer (GstDroidVDec * dec,
   return ret;
 }
 
-static void
-gst_droidvdec_frame_available (void *user)
+static bool
+gst_droidvdec_frame_available (void *user, DroidMediaBuffer * buffer)
 {
   GstDroidVDec *dec = (GstDroidVDec *) user;
   GstVideoDecoder *decoder = GST_VIDEO_DECODER (dec);
-  GstMemory *mem;
   guint width, height;
   GstVideoCodecFrame *frame;
-  DroidMediaBuffer *buffer;
-  GstBuffer *buff;
+  GstBuffer *buff = NULL;
+  GstBufferPool *pool;
   GstVideoCropMeta *crop_meta;
-  DroidMediaBufferCallbacks cb;
   DroidMediaBufferInfo droid_info;
   GstVideoInfo video_info;
-  GstFlowReturn flow_ret;
+  bool ret = true;
 
   GST_DEBUG_OBJECT (dec, "frame available");
 
   GST_VIDEO_DECODER_STREAM_LOCK (decoder);
 
   if (dec->dirty) {
-    goto acquire_and_release;
+    goto error;
   }
 
   if (dec->downstream_flow_ret != GST_FLOW_OK) {
     GST_DEBUG_OBJECT (dec, "not handling frame in error state: %s",
         gst_flow_get_name (dec->downstream_flow_ret));
-    goto acquire_and_release;
+    goto error;
   }
 
-  flow_ret = gst_buffer_pool_acquire_buffer (dec->pool, &buff, NULL);
+  pool = gst_video_decoder_get_buffer_pool (decoder);
 
-  if (flow_ret != GST_FLOW_OK) {
-    GST_WARNING_OBJECT (dec, "failed to acquire buffer from pool: %s",
-        gst_flow_get_name (flow_ret));
-    goto acquire_and_release;
+  if (G_UNLIKELY (!pool)) {
+    GST_WARNING_OBJECT (dec, "video decoder doesn't have a buffer pool");
+  } else {
+    buff = gst_droid_buffer_pool_acquire_media_buffer (pool, buffer);
+
+    gst_object_unref (pool);
   }
 
-  cb.ref = (DroidMediaCallback) gst_buffer_ref;
-  cb.unref = (DroidMediaCallback) gst_buffer_unref;
-  cb.data = buff;
-
-  mem =
-      gst_droid_media_buffer_allocator_alloc (dec->allocator, dec->queue, &cb);
-
-  if (!mem) {
-    /* TODO: what should we do here? */
-    GST_ERROR_OBJECT (dec, "failed to acquire buffer from droidmedia");
-    gst_buffer_unref (buff);
-    GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
-    return;
+  if (G_UNLIKELY (!buff)) {
+    GST_DEBUG_OBJECT (dec,
+        "unable to acquire a gstreamer buffer for a droid media buffer");
+    goto error;
   }
 
-  buffer = gst_droid_media_buffer_memory_get_buffer (mem);
   droid_media_buffer_get_info (buffer, &droid_info);
-
-  gst_buffer_insert_memory (buff, 0, mem);
-
-  /* Now we can configure the state */
-  if (G_UNLIKELY (!dec->out_state)) {
-    if (!gst_droidvdec_configure_state (decoder, droid_info.width,
-            droid_info.height)) {
-      dec->downstream_flow_ret = GST_FLOW_ERROR;
-      gst_buffer_unref (buff);
-      GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
-      return;
-    }
-  }
-
-  /* we don't want to access the memory afterwards */
-  mem = NULL;
-  buffer = NULL;
 
   if (dec->bytes_per_pixel != 0) {
     width = ALIGN_SIZE (droid_info.stride, dec->h_align) / dec->bytes_per_pixel;
@@ -519,7 +516,6 @@ gst_droidvdec_frame_available (void *user)
   }
 
   gst_video_info_set_format (&video_info, dec->format, width, height);
-
 
   crop_meta = gst_buffer_add_video_crop_meta (buff);
   crop_meta->x = droid_info.crop_rect.left;
@@ -539,32 +535,34 @@ gst_droidvdec_frame_available (void *user)
   if (G_UNLIKELY (!frame)) {
     /* TODO: what should we do here? */
     GST_WARNING_OBJECT (dec, "buffer without frame");
+
+    /* We've acquired the droid media buffer at this point and unref'ing the GstBuffer
+     * will release it back to the queue, so from a queue manangement perspective this
+     * function has succeeded. */
     gst_buffer_unref (buff);
-    GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
-    return;
+  } else {
+    frame->output_buffer = buff;
+
+    /* We get the timestamp in ns already */
+    frame->pts = droid_info.timestamp;
+
+    /* we have a ref acquired by _get_oldest_frame()
+     * but we don't drop it because _finish_frame() assumes 2 refs.
+     * A ref that we obtained via _handle_frame() which we dropped already
+     * so we need to compensate it and the 2nd ref which is already owned by
+     * the base class GstVideoDecoder
+     */
+    dec->downstream_flow_ret = gst_droidvdec_finish_frame (decoder, frame);
   }
 
-  frame->output_buffer = buff;
-
-  /* We get the timestamp in ns already */
-  frame->pts = droid_info.timestamp;
-
-  /* we have a ref acquired by _get_oldest_frame()
-   * but we don't drop it because _finish_frame() assumes 2 refs.
-   * A ref that we obtained via _handle_frame() which we dropped already
-   * so we need to compensate it and the 2nd ref which is already owned by
-   * the base class GstVideoDecoder
-   */
-  dec->downstream_flow_ret = gst_droidvdec_finish_frame (decoder, frame);
-
+out:
   GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
-  return;
 
-acquire_and_release:
-  /* we can not use our cb struct here so ask droidmedia to do
-   * the work instead */
-  droid_media_buffer_queue_acquire_and_release (dec->queue, NULL);
-  GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
+  return ret;
+
+error:
+  ret = false;
+  goto out;
 }
 
 static void
@@ -672,20 +670,16 @@ gst_droidvdec_signal_eos (void *data)
 
   GST_DEBUG_OBJECT (dec, "codec signaled EOS");
 
-  g_mutex_lock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_LOCK (dec);
 
   if (dec->state != GST_DROID_VDEC_STATE_WAITING_FOR_EOS) {
     GST_WARNING_OBJECT (dec, "codec signaled EOS but we are not expecting it");
   }
 
-  if (dec->pool) {
-    gst_buffer_pool_set_flushing (dec->pool, TRUE);
-  }
-
   dec->state = GST_DROID_VDEC_STATE_EOS;
 
   g_cond_signal (&dec->state_cond);
-  g_mutex_unlock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_UNLOCK (dec);
 }
 
 static void
@@ -695,19 +689,19 @@ gst_droidvdec_error (void *data, int err)
 
   GST_DEBUG_OBJECT (dec, "codec error");
 
-  g_mutex_lock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_LOCK (dec);
 
   if (dec->state == GST_DROID_VDEC_STATE_WAITING_FOR_EOS) {
     /* Gotta love Android. We will ignore errors if we are expecting EOS */
     g_cond_signal (&dec->state_cond);
-    g_mutex_unlock (&dec->state_lock);
-    goto out;
+    GST_DROIDVDEC_STATE_UNLOCK (dec);
+    return;
   }
 
   /* just in case */
   g_cond_signal (&dec->state_cond);
 
-  g_mutex_unlock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_UNLOCK (dec);
 
   GST_VIDEO_DECODER_STREAM_LOCK (dec);
   dec->downstream_flow_ret = GST_FLOW_ERROR;
@@ -715,11 +709,6 @@ gst_droidvdec_error (void *data, int err)
 
   GST_ELEMENT_ERROR (dec, LIBRARY, FAILED, NULL,
       ("error 0x%x from android codec", -err));
-
-out:
-  if (dec->pool) {
-    gst_buffer_pool_set_flushing (dec->pool, TRUE);
-  }
 }
 
 static int
@@ -759,18 +748,25 @@ gst_droidvdec_configure_state (GstVideoDecoder * decoder, guint width,
         gst_droidvdec_convert_yuv420_packed_semi_planar_to_i420, 1, 128, 32},
     {&constants.QOMX_COLOR_FormatYUV420PackedSemiPlanar64x32Tile2m8ka,
         GST_VIDEO_FORMAT_NV12_64Z32, NULL, 0, 0, 0},
-    {&constants.OMX_COLOR_FormatYUV420Planar, GST_VIDEO_FORMAT_I420,
+    {&constants.OMX_COLOR_FormatYUV420Planar,
+          GST_VIDEO_FORMAT_I420,
         gst_droidvdec_convert_yuv420_planar_to_i420, 1, 4, 1},
-    {&constants.OMX_COLOR_FormatYUV420PackedPlanar, GST_VIDEO_FORMAT_I420, NULL,
+    {&constants.OMX_COLOR_FormatYUV420PackedPlanar,
+          GST_VIDEO_FORMAT_I420, NULL,
         1, 1, 1},
     {&constants.OMX_COLOR_FormatYUV420SemiPlanar, GST_VIDEO_FORMAT_NV12,
         gst_droidvdec_convert_yuv420_semi_planar_to_i420, 1, 1, 1},
-    {&constants.OMX_COLOR_FormatL8, GST_VIDEO_FORMAT_GRAY8, NULL, 1, 1, 1},
-    {&constants.OMX_COLOR_FormatYUV422SemiPlanar, GST_VIDEO_FORMAT_NV16, NULL,
+    {&constants.OMX_COLOR_FormatL8, GST_VIDEO_FORMAT_GRAY8, NULL, 1, 1,
+        1},
+    {&constants.OMX_COLOR_FormatYUV422SemiPlanar, GST_VIDEO_FORMAT_NV16,
+          NULL,
         1, 1, 1},
-    {&constants.OMX_COLOR_FormatYCbYCr, GST_VIDEO_FORMAT_YUY2, NULL, 1, 1, 1},
-    {&constants.OMX_COLOR_FormatYCrYCb, GST_VIDEO_FORMAT_YVYU, NULL, 1, 1, 1},
-    {&constants.OMX_COLOR_FormatCbYCrY, GST_VIDEO_FORMAT_UYVY, NULL, 1, 1, 1},
+    {&constants.OMX_COLOR_FormatYCbYCr, GST_VIDEO_FORMAT_YUY2, NULL, 1,
+        1, 1},
+    {&constants.OMX_COLOR_FormatYCrYCb, GST_VIDEO_FORMAT_YVYU, NULL, 1,
+        1, 1},
+    {&constants.OMX_COLOR_FormatCbYCrY, GST_VIDEO_FORMAT_UYVY, NULL, 1,
+        1, 1},
     {&constants.OMX_COLOR_Format32bitARGB8888,
           /* There is a mismatch in omxil specification 4.2.1 between
            * OMX_COLOR_Format32bitARGB8888 and its description
@@ -783,9 +779,11 @@ gst_droidvdec_configure_state (GstVideoDecoder * decoder, guint width,
           GST_VIDEO_FORMAT_ARGB,
           NULL,
         4, 4, 1},
-    {&constants.OMX_COLOR_Format16bitRGB565, GST_VIDEO_FORMAT_RGB16, NULL, 2, 4,
+    {&constants.OMX_COLOR_Format16bitRGB565, GST_VIDEO_FORMAT_RGB16,
+          NULL, 2, 4,
         1},
-    {&constants.OMX_COLOR_Format16bitBGR565, GST_VIDEO_FORMAT_BGR16, NULL, 2, 4,
+    {&constants.OMX_COLOR_Format16bitBGR565, GST_VIDEO_FORMAT_BGR16,
+          NULL, 2, 4,
         1}
   };
 
@@ -871,7 +869,7 @@ gst_droidvdec_configure_state (GstVideoDecoder * decoder, guint width,
 
   if (dec->use_hardware_buffers) {
     GstCapsFeatures *feature =
-        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_BUFFER,
+        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER,
         NULL);
     gst_caps_set_features (dec->out_state->caps, 0, feature);
   } else {
@@ -909,6 +907,80 @@ error:
 }
 
 static gboolean
+gst_droidvdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+{
+  GstCaps *caps;
+  GstCapsFeatures *features;
+
+  gst_query_parse_allocation (query, &caps, NULL);
+
+  features = gst_caps_get_features (caps, 0);
+
+  /* If we've negotiated caps with the droid memory queue buffers feature then ensure we use
+   * a buffer pool that supports that. Otherwise let the default implementation decide. */
+  if (gst_caps_features_contains (features,
+          GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER)) {
+    GstBufferPool *pool = NULL;
+    gint i;
+    guint min, max;
+    guint size;
+    gint count = gst_query_get_n_allocation_pools (query);
+
+    for (i = 0; i < count; ++i) {
+      GstAllocator *allocator;
+      GstStructure *config;
+
+      gst_query_parse_nth_allocation_pool (query, i, &pool, &size, &min, &max);
+      config = gst_buffer_pool_get_config (pool);
+      gst_buffer_pool_config_get_allocator (config, &allocator, NULL);
+      if (allocator
+          && g_strcmp0 (allocator->mem_type,
+              GST_ALLOCATOR_DROID_MEDIA_BUFFER) == 0) {
+        break;
+      } else {
+        gst_object_unref (pool);
+        pool = NULL;
+      }
+    }
+
+    /* The downstream may have other ideas about what the pool size should be but the
+     * queue we're working with has a fixed size so that's the number of buffers we'll
+     * go with. */
+    min = 0;
+    max = droid_media_buffer_queue_length ();
+
+    if (!pool) {
+      /* A downstream which understands the queue buffers should also have provided a pool
+       * but for completeness add this a fallback. */
+      GstStructure *config;
+      GstVideoInfo video_info;
+      gst_video_info_from_caps (&video_info, caps);
+
+      pool = gst_droid_buffer_pool_new ();
+      size = video_info.finfo->format == GST_VIDEO_FORMAT_ENCODED
+          ? 1 : video_info.size;
+
+      config = gst_buffer_pool_get_config (pool);
+      gst_buffer_pool_config_set_params (config, caps, size, min, max);
+
+      if (!gst_buffer_pool_set_config (pool, config)) {
+        GST_ERROR_OBJECT (decoder, "Failed to set buffer pool configuration");
+      }
+    }
+
+    gst_query_set_nth_allocation_pool (query, 0, pool, size, min, max);
+    while (gst_query_get_n_allocation_pools (query) > 1)
+      gst_query_remove_nth_allocation_pool (query, 1);
+
+    gst_object_unref (pool);
+    pool = NULL;
+  }
+
+  return GST_VIDEO_DECODER_CLASS (parent_class)->decide_allocation (decoder,
+      query);
+}
+
+static gboolean
 gst_droidvdec_stop (GstVideoDecoder * decoder)
 {
   GstDroidVDec *dec = GST_DROIDVDEC (decoder);
@@ -919,7 +991,6 @@ gst_droidvdec_stop (GstVideoDecoder * decoder)
     droid_media_codec_stop (dec->codec);
     droid_media_codec_destroy (dec->codec);
     dec->codec = NULL;
-    dec->queue = NULL;
   }
 
   if (dec->in_state) {
@@ -944,10 +1015,6 @@ gst_droidvdec_stop (GstVideoDecoder * decoder)
     dec->convert = NULL;
   }
 
-  if (dec->pool) {
-    gst_buffer_pool_set_active (dec->pool, FALSE);
-  }
-
   return TRUE;
 }
 
@@ -961,15 +1028,7 @@ gst_droidvdec_stop_loop (GstDroidVDec * dec)
    */
   GST_DEBUG_OBJECT (dec, "stop loop");
 
-  if (dec->pool) {
-    gst_buffer_pool_set_flushing (dec->pool, TRUE);
-  }
-
   gst_pad_stop_task (GST_VIDEO_DECODER_SRC_PAD (GST_VIDEO_DECODER (dec)));
-
-  if (dec->pool) {
-    gst_buffer_pool_set_flushing (dec->pool, FALSE);
-  }
 
   dec->running = FALSE;
 }
@@ -982,11 +1041,6 @@ gst_droidvdec_finalize (GObject * object)
   GST_DEBUG_OBJECT (dec, "finalize");
 
   gst_droidvdec_stop (GST_VIDEO_DECODER (dec));
-
-  if (dec->pool) {
-    gst_object_unref (dec->pool);
-    dec->pool = NULL;
-  }
 
   gst_object_unref (dec->allocator);
   dec->allocator = NULL;
@@ -1087,7 +1141,7 @@ gst_droidvdec_set_format (GstVideoDecoder * decoder, GstVideoCodecState * state)
   for (i = 0; i < count; ++i) {
     features = gst_caps_get_features (caps, i);
     if (gst_caps_features_contains
-        (features, GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_BUFFER)) {
+        (features, GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER)) {
       dec->use_hardware_buffers = TRUE;
     }
   }
@@ -1118,52 +1172,60 @@ static GstFlowReturn
 gst_droidvdec_finish (GstVideoDecoder * decoder)
 {
   GstDroidVDec *dec = GST_DROIDVDEC (decoder);
+  GstBufferPool *pool = NULL;
 
   GST_DEBUG_OBJECT (dec, "finish");
 
-  g_mutex_lock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_LOCK (dec);
 
   /* since we release the stream lock, we can get called again */
   if (dec->state == GST_DROID_VDEC_STATE_WAITING_FOR_EOS) {
     GST_DEBUG_OBJECT (dec, "already finishing");
-    g_mutex_unlock (&dec->state_lock);
+    GST_DROIDVDEC_STATE_UNLOCK (dec);
     return GST_FLOW_NOT_SUPPORTED;
   }
 
   if (dec->codec && dec->state == GST_DROID_VDEC_STATE_OK) {
+    GstBufferPool *pool = gst_video_decoder_get_buffer_pool (decoder);
+
     GST_INFO_OBJECT (dec, "draining");
     dec->state = GST_DROID_VDEC_STATE_WAITING_FOR_EOS;
     droid_media_codec_drain (dec->codec);
-  } else {
-    goto out;
+
+    /* release the lock to allow _frame_available () to do its job */
+    GST_LOG_OBJECT (dec, "releasing stream lock");
+    GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
+    /* Now we wait for the codec to signal EOS */
+    g_cond_wait (&dec->state_cond, &dec->state_lock);
+
+    droid_media_buffer_queue_set_callbacks (droid_media_codec_get_buffer_queue
+        (dec->codec), NULL, NULL);
+
+    GST_DROIDVDEC_STATE_UNLOCK (dec);
+
+    if (pool) {
+      gst_droid_buffer_pool_media_buffers_invalidated (pool);
+      gst_object_unref (pool);
+    }
+
+    GST_VIDEO_DECODER_STREAM_LOCK (decoder);
+    GST_DROIDVDEC_STATE_LOCK (dec);
+    GST_LOG_OBJECT (dec, "acquired stream lock");
+
+    if (dec->codec) {
+      droid_media_codec_stop (dec->codec);
+      droid_media_codec_destroy (dec->codec);
+      dec->codec = NULL;
+    }
+
+    dec->dirty = TRUE;
   }
 
-  /* release the lock to allow _frame_available () to do its job */
-  GST_LOG_OBJECT (dec, "releasing stream lock");
-  GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
-  /* Now we wait for the codec to signal EOS */
-  g_cond_wait (&dec->state_cond, &dec->state_lock);
-  g_mutex_unlock (&dec->state_lock);
-  GST_VIDEO_DECODER_STREAM_LOCK (decoder);
-  g_mutex_lock (&dec->state_lock);
-  GST_LOG_OBJECT (dec, "acquired stream lock");
-
-  /* We drained the codec. Better to recreate it. */
-  if (dec->codec) {
-    droid_media_codec_stop (dec->codec);
-    droid_media_codec_destroy (dec->codec);
-    dec->codec = NULL;
-    dec->queue = NULL;
-  }
-
-  dec->dirty = TRUE;
-
-out:
   dec->state = GST_DROID_VDEC_STATE_OK;
 
-  GST_DEBUG_OBJECT (dec, "finished");
+  GST_DROIDVDEC_STATE_UNLOCK (dec);
 
-  g_mutex_unlock (&dec->state_lock);
+  GST_DEBUG_OBJECT (dec, "finished");
 
   return GST_FLOW_OK;
 }
@@ -1200,14 +1262,18 @@ gst_droidvdec_handle_frame (GstVideoDecoder * decoder,
     goto error;
   }
 
-  g_mutex_lock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_LOCK (dec);
   if (dec->state == GST_DROID_VDEC_STATE_EOS) {
     GST_WARNING_OBJECT (dec, "got frame in eos state");
-    g_mutex_unlock (&dec->state_lock);
+    GST_DROIDVDEC_STATE_UNLOCK (dec);
     ret = GST_FLOW_EOS;
     goto error;
+  } else if (dec->state == GST_DROID_VDEC_STATE_WAITING_FOR_EOS) {
+    GST_DROIDVDEC_STATE_UNLOCK (dec);
+    ret = GST_FLOW_FLUSHING;
+    goto error;
   }
-  g_mutex_unlock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_UNLOCK (dec);
 
   /* We must create the codec before we process any data. _create_codec will call
    * construct_decoder_codec_data which will store the nal prefix length for H264.
@@ -1246,8 +1312,9 @@ gst_droidvdec_handle_frame (GstVideoDecoder * decoder,
    * which breaks timestamping.
    */
   data.ts =
-      GST_CLOCK_TIME_IS_VALID (frame->pts) ? GST_TIME_AS_USECONDS (frame->
-      pts) : GST_TIME_AS_USECONDS (frame->dts);
+      GST_CLOCK_TIME_IS_VALID (frame->
+      pts) ? GST_TIME_AS_USECONDS (frame->pts) : GST_TIME_AS_USECONDS (frame->
+      dts);
   data.sync = GST_VIDEO_CODEC_FRAME_IS_SYNC_POINT (frame) ? true : false;
 
   /* This can deadlock if droidmedia/stagefright input buffer queue is full thus we
@@ -1261,6 +1328,7 @@ gst_droidvdec_handle_frame (GstVideoDecoder * decoder,
   GST_VIDEO_DECODER_STREAM_UNLOCK (decoder);
   droid_media_codec_queue (dec->codec, &data, &cb);
   GST_VIDEO_DECODER_STREAM_LOCK (decoder);
+
   GST_LOG_OBJECT (dec, "acquired stream lock");
 
   /* from now on decoder owns a frame reference */
@@ -1272,15 +1340,15 @@ gst_droidvdec_handle_frame (GstVideoDecoder * decoder,
     goto unref;
   }
 
-  g_mutex_lock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_LOCK (dec);
   if (dec->state == GST_DROID_VDEC_STATE_EOS) {
     GST_WARNING_OBJECT (dec, "got frame in eos state");
-    g_mutex_unlock (&dec->state_lock);
+    GST_DROIDVDEC_STATE_UNLOCK (dec);
     ret = GST_FLOW_EOS;
     goto unref;
   }
 
-  g_mutex_unlock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_UNLOCK (dec);
 
   ret = GST_FLOW_OK;
 
@@ -1297,7 +1365,7 @@ error:
   /* don't leak the frame */
   gst_video_decoder_release_frame (decoder, frame);
 
-  return ret;
+  goto out;
 }
 
 static gboolean
@@ -1316,12 +1384,15 @@ gst_droidvdec_flush (GstVideoDecoder * decoder)
    * We will just mark the decoder as "dirty" so the next handle_frame can recreate it
    */
 
-  dec->dirty = TRUE;
+
 
   dec->downstream_flow_ret = GST_FLOW_OK;
-  g_mutex_lock (&dec->state_lock);
-  dec->state = GST_DROID_VDEC_STATE_OK;
-  g_mutex_unlock (&dec->state_lock);
+  GST_DROIDVDEC_STATE_LOCK (dec);
+  if (dec->state != GST_DROID_VDEC_STATE_WAITING_FOR_EOS) {
+    dec->dirty = TRUE;
+    dec->state = GST_DROID_VDEC_STATE_OK;
+  }
+  GST_DROIDVDEC_STATE_UNLOCK (dec);
 
   return TRUE;
 }
@@ -1370,7 +1441,6 @@ gst_droidvdec_init (GstDroidVDec * dec)
   gst_video_decoder_set_needs_format (GST_VIDEO_DECODER (dec), TRUE);
 
   dec->codec = NULL;
-  dec->queue = NULL;
   dec->codec_type = NULL;
   dec->downstream_flow_ret = GST_FLOW_OK;
   dec->state = GST_DROID_VDEC_STATE_OK;
@@ -1385,7 +1455,6 @@ gst_droidvdec_init (GstDroidVDec * dec)
   dec->in_state = NULL;
   dec->out_state = NULL;
   dec->convert = NULL;
-  dec->pool = NULL;
 }
 
 static void
@@ -1423,6 +1492,8 @@ gst_droidvdec_class_init (GstDroidVDecClass * klass)
   gstvideodecoder_class->stop = GST_DEBUG_FUNCPTR (gst_droidvdec_stop);
   gstvideodecoder_class->set_format =
       GST_DEBUG_FUNCPTR (gst_droidvdec_set_format);
+  gstvideodecoder_class->decide_allocation =
+      GST_DEBUG_FUNCPTR (gst_droidvdec_decide_allocation);
   gstvideodecoder_class->finish = GST_DEBUG_FUNCPTR (gst_droidvdec_finish);
   gstvideodecoder_class->handle_frame =
       GST_DEBUG_FUNCPTR (gst_droidvdec_handle_frame);

--- a/gst/droidcodec/gstdroidvdec.h
+++ b/gst/droidcodec/gstdroidvdec.h
@@ -60,7 +60,6 @@ struct _GstDroidVDec
 {
   GstVideoDecoder parent;
   DroidMediaCodec *codec;
-  DroidMediaBufferQueue *queue;
   GstAllocator *allocator;
   GstDroidCodec *codec_type;
 
@@ -68,8 +67,6 @@ struct _GstDroidVDec
   GstDroidVDecState state;
   GMutex state_lock;
   GCond state_cond;
-
-  GstBufferPool *pool;
 
   /* protected by decoder stream lock */
   GstFlowReturn downstream_flow_ret;

--- a/gst/droideglsink/Makefile.am
+++ b/gst/droideglsink/Makefile.am
@@ -5,5 +5,5 @@ libgstdroideglsink_la_CFLAGS = $(GST_CFLAGS) $(NGI_CFLAGS) $(EGL_CFLAGS) \
 
 libgstdroideglsink_la_LIBADD = $(GST_LIBS) $(NGI_LIBS) $(EGL_LIBS)
 
-libgstdroideglsink_la_SOURCES = gstdroideglsink.c
-noinst_HEADERS = gstdroideglsink.h
+libgstdroideglsink_la_SOURCES = gstdroideglsink.c gstdroidvideotexturesink.c
+noinst_HEADERS = gstdroideglsink.h gstdroidvideotexturesink.h

--- a/gst/droideglsink/gstdroideglsink.h
+++ b/gst/droideglsink/gstdroideglsink.h
@@ -39,6 +39,8 @@ G_BEGIN_DECLS
   (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_DROIDEGLSINK))
 #define GST_IS_DROIDEGLSINK_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_DROIDEGLSINK))
+#define GST_DROIDEGLSINK_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj), GST_TYPE_DROIDEGLSINK, GstDroidEglSinkClass))
 
 typedef struct _GstDroidEglSink GstDroidEglSink;
 typedef struct _GstDroidEglSinkClass GstDroidEglSinkClass;
@@ -47,27 +49,20 @@ struct _GstDroidEglSink
 {
   GstVideoSink parent;
 
-  gint fps_n;
-  gint fps_d;
-
-  GstBuffer *acquired_buffer;
-  GstBuffer *last_buffer;
+  GstBufferPool *pool;
+  gulong invalidated_signal_id;
   EGLDisplay dpy;
-  EGLImageKHR image;
-  EGLSyncKHR sync;
   GMutex lock;
-
-  GstAllocator *allocator;
-
-  PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
-  PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
-  PFNEGLCLIENTWAITSYNCKHRPROC eglClientWaitSyncKHR;
-  PFNEGLDESTROYSYNCKHRPROC eglDestroySyncKHR;
 };
 
 struct _GstDroidEglSinkClass
 {
   GstVideoSinkClass parent_class;
+
+  void (*signal_show_frame)            (GstVideoSink *sink, GstBuffer *buffer);
+  void (*signal_buffers_invalidated)   (GstVideoSink *sink);
+
+  void (* buffers_invalidated) (GstDroidEglSink *sink);
 };
 
 GType gst_droideglsink_get_type (void);

--- a/gst/droideglsink/gstdroidvideotexturesink.c
+++ b/gst/droideglsink/gstdroidvideotexturesink.c
@@ -1,0 +1,648 @@
+/*
+ * gst-droid
+ *
+ * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
+ * Copyright (C) 2015 Jolla LTD.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "gstdroidvideotexturesink.h"
+#include <gst/video/video.h>
+#include <gst/interfaces/nemoeglimagememory.h>
+#include <gst/interfaces/nemovideotexture.h>
+#include "gst/droid/gstdroidmediabuffer.h"
+#include "gst/droid/gstdroidbufferpool.h"
+
+GST_DEBUG_CATEGORY_EXTERN (gst_droid_videotexturesink_debug);
+#define GST_CAT_DEFAULT gst_droid_videotexturesink_debug
+
+static void
+gst_droidvideotexturesink_video_texture_init (NemoGstVideoTextureClass * iface);
+
+#define gst_droidvideotexturesink_parent_class parent_class
+G_DEFINE_TYPE_WITH_CODE (GstDroidVideoTextureSink, gst_droidvideotexturesink,
+    GST_TYPE_DROIDEGLSINK, G_IMPLEMENT_INTERFACE (NEMO_GST_TYPE_VIDEO_TEXTURE,
+        gst_droidvideotexturesink_video_texture_init));
+
+enum
+{
+  PROP_0,
+  PROP_EGL_DISPLAY
+};
+
+static void
+gst_droidvideotexturesink_destroy_sync (GstDroidVideoTextureSink * sink)
+{
+  GST_DEBUG_OBJECT (sink, "destroy sync %p", sink->sync);
+
+  if (sink->sync) {
+    sink->eglDestroySyncKHR (sink->dpy, sink->sync);
+    sink->sync = NULL;
+  }
+}
+
+static void
+gst_droidvideotexturesink_wait_sync (GstDroidVideoTextureSink * sink)
+{
+  GST_DEBUG_OBJECT (sink, "wait sync %p", sink->sync);
+
+  if (sink->sync) {
+    /* We will behave like Android does */
+    EGLint result =
+        sink->eglClientWaitSyncKHR (sink->dpy, sink->sync, 0, EGL_FOREVER_KHR);
+    if (result == EGL_FALSE) {
+      GST_WARNING_OBJECT (sink, "error 0x%x waiting for fence", eglGetError ());
+    } else if (result == EGL_TIMEOUT_EXPIRED_KHR) {
+      GST_WARNING_OBJECT (sink, "timeout waiting for fence");
+    }
+
+    gst_droidvideotexturesink_destroy_sync (sink);
+  }
+}
+
+static gboolean
+gst_droidvideotexturesink_set_caps (GstBaseSink * bsink, GstCaps * caps)
+{
+  GstDroidVideoTextureSink *sink;
+  GstVideoSink *vsink;
+  GstVideoInfo info;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (bsink);
+  vsink = GST_VIDEO_SINK (bsink);
+
+  GST_DEBUG_OBJECT (sink, "set caps with %" GST_PTR_FORMAT, caps);
+
+  if (!gst_video_info_from_caps (&info, caps)) {
+    GST_ELEMENT_ERROR (sink, STREAM, FORMAT, (NULL),
+        ("Could not locate image format from caps %" GST_PTR_FORMAT, caps));
+    return FALSE;
+  }
+
+  sink->fps_n = info.fps_n;
+  sink->fps_d = info.fps_d;
+
+  GST_VIDEO_SINK_WIDTH (vsink) = info.width;
+  GST_VIDEO_SINK_HEIGHT (vsink) = info.height;
+
+  return TRUE;
+}
+
+static void
+gst_droidvideotexturesink_get_times (GstBaseSink * bsink, GstBuffer * buf,
+    GstClockTime * start, GstClockTime * end)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (bsink);
+
+  if (GST_BUFFER_TIMESTAMP_IS_VALID (buf)) {
+    *start = GST_BUFFER_TIMESTAMP (buf);
+    if (GST_BUFFER_DURATION_IS_VALID (buf)) {
+      *end = *start + GST_BUFFER_DURATION (buf);
+    } else {
+      if (sink->fps_n > 0) {
+        *end = *start +
+            gst_util_uint64_scale_int (GST_SECOND, sink->fps_d, sink->fps_n);
+      }
+    }
+  }
+}
+
+static gboolean
+gst_droidvideotexturesink_start (GstBaseSink * bsink)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (bsink);
+
+  GST_DEBUG_OBJECT (sink, "start");
+
+  sink->fps_n = 0;
+  sink->fps_d = 1;
+
+  sink->image = EGL_NO_IMAGE_KHR;
+  sink->sync = NULL;
+  sink->eglDestroyImageKHR = NULL;
+  sink->eglClientWaitSyncKHR = NULL;
+  sink->eglDestroySyncKHR = NULL;
+
+  return TRUE;
+}
+
+static gboolean
+gst_droidvideotexturesink_stop (GstBaseSink * bsink)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (bsink);
+
+  GST_DEBUG_OBJECT (sink, "stop");
+
+  if (sink->sync) {
+    gst_droidvideotexturesink_destroy_sync (sink);
+  }
+
+  g_mutex_lock (&sink->lock);
+
+  if (sink->image) {
+    GST_WARNING_OBJECT (sink, "destroying leftover EGLImageKHR");
+    sink->eglDestroyImageKHR (sink->dpy, sink->image);
+    sink->image = EGL_NO_IMAGE_KHR;
+  }
+
+  if (sink->acquired_buffer) {
+    GST_WARNING_OBJECT (sink, "freeing leftover acquired buffer");
+    gst_buffer_unref (sink->acquired_buffer);
+    sink->acquired_buffer = NULL;
+  }
+
+  g_mutex_unlock (&sink->lock);
+
+  if (sink->last_buffer) {
+    GST_INFO_OBJECT (sink, "freeing leftover last buffer");
+    gst_buffer_unref (sink->last_buffer);
+    sink->last_buffer = NULL;
+  }
+
+  return TRUE;
+}
+
+static GstFlowReturn
+gst_droidvideotexturesink_show_frame (GstVideoSink * vsink, GstBuffer * buf)
+{
+  GstDroidVideoTextureSink *sink;
+  gint n_memory;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (vsink);
+
+  GST_DEBUG_OBJECT (sink, "show frame");
+
+  n_memory = gst_buffer_n_memory (buf);
+
+  if (G_UNLIKELY (n_memory == 0)) {
+    GST_WARNING_OBJECT (sink, "received an empty buffer");
+    /* we will just drop the buffer without errors */
+    return GST_FLOW_OK;
+  }
+
+  g_mutex_lock (&sink->lock);
+  if (sink->acquired_buffer) {
+    GST_INFO_OBJECT (sink,
+        "acquired buffer exists. Not replacing current buffer");
+    g_mutex_unlock (&sink->lock);
+    return GST_FLOW_OK;
+  }
+
+  GST_LOG_OBJECT (sink, "replacing buffer %p with buffer %p", sink->last_buffer,
+      buf);
+
+  gst_buffer_replace (&sink->last_buffer, buf);
+
+  g_mutex_unlock (&sink->lock);
+
+  nemo_gst_video_texture_frame_ready (NEMO_GST_VIDEO_TEXTURE (sink), 0);
+
+  return GST_FLOW_OK;
+}
+
+static gboolean
+gst_droidvideotexturesink_event (GstBaseSink * bsink, GstEvent * event)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (bsink);
+
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_FLUSH_START:
+    case GST_EVENT_EOS:
+      GST_INFO_OBJECT (sink,
+          "emitting frame-ready with -1 after %" GST_PTR_FORMAT, event);
+      g_mutex_lock (&sink->lock);
+
+      if (sink->last_buffer) {
+        gst_buffer_unref (sink->last_buffer);
+        sink->last_buffer = NULL;
+      }
+
+      g_mutex_unlock (&sink->lock);
+      nemo_gst_video_texture_frame_ready (NEMO_GST_VIDEO_TEXTURE (sink), -1);
+      break;
+
+    default:
+      break;
+  }
+
+  return GST_BASE_SINK_CLASS (parent_class)->event (bsink, event);
+}
+
+static void
+gst_droidvideotexturesink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstDroidVideoTextureSink *sink;
+
+  g_return_if_fail (GST_IS_DROIDVIDEOTEXTURESINK (object));
+
+  sink = GST_DROIDVIDEOTEXTURESINK (object);
+
+  switch (prop_id) {
+    case PROP_EGL_DISPLAY:
+      g_mutex_lock (&sink->lock);
+      sink->dpy = g_value_get_pointer (value);
+      g_mutex_unlock (&sink->lock);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_droidvideotexturesink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstDroidVideoTextureSink *sink;
+
+  g_return_if_fail (GST_IS_DROIDVIDEOTEXTURESINK (object));
+
+  sink = GST_DROIDVIDEOTEXTURESINK (object);
+
+  switch (prop_id) {
+    case PROP_EGL_DISPLAY:
+      g_mutex_lock (&sink->lock);
+      g_value_set_pointer (value, sink->dpy);
+      g_mutex_unlock (&sink->lock);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_droidvideotexturesink_finalize (GObject * object)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (object);
+
+  g_mutex_clear (&sink->lock);
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+static void
+gst_droidvideotexturesink_init (GstDroidVideoTextureSink * sink)
+{
+  gst_base_sink_set_last_sample_enabled (GST_BASE_SINK (sink), FALSE);
+
+  sink->fps_n = 0;
+  sink->fps_d = 0;
+  sink->acquired_buffer = NULL;
+  sink->last_buffer = NULL;
+  sink->dpy = EGL_NO_DISPLAY;
+  sink->image = EGL_NO_IMAGE_KHR;
+  sink->sync = NULL;
+  g_mutex_init (&sink->lock);
+  sink->eglDestroyImageKHR = NULL;
+  sink->eglClientWaitSyncKHR = NULL;
+  sink->eglDestroySyncKHR = NULL;
+}
+
+static void
+gst_droidvideotexturesink_class_init (GstDroidVideoTextureSinkClass * klass)
+{
+  GObjectClass *gobject_class;
+  GstElementClass *gstelement_class;
+  GstBaseSinkClass *gstbasesink_class;
+  GstVideoSinkClass *videosink_class;
+
+  gobject_class = (GObjectClass *) klass;
+  gstelement_class = (GstElementClass *) klass;
+  gstbasesink_class = (GstBaseSinkClass *) klass;
+  videosink_class = (GstVideoSinkClass *) klass;
+
+  gst_element_class_set_static_metadata (gstelement_class,
+      "Video sink", "Sink/Video/Device",
+      "EGL based videosink", "Mohammed Sameer <msameer@foolab.org>");
+
+  gobject_class->finalize = gst_droidvideotexturesink_finalize;
+  gobject_class->set_property = gst_droidvideotexturesink_set_property;
+  gobject_class->get_property = gst_droidvideotexturesink_get_property;
+
+  gstbasesink_class->set_caps =
+      GST_DEBUG_FUNCPTR (gst_droidvideotexturesink_set_caps);
+  gstbasesink_class->get_times =
+      GST_DEBUG_FUNCPTR (gst_droidvideotexturesink_get_times);
+  gstbasesink_class->start =
+      GST_DEBUG_FUNCPTR (gst_droidvideotexturesink_start);
+  gstbasesink_class->stop = GST_DEBUG_FUNCPTR (gst_droidvideotexturesink_stop);
+  gstbasesink_class->event =
+      GST_DEBUG_FUNCPTR (gst_droidvideotexturesink_event);
+  videosink_class->show_frame =
+      GST_DEBUG_FUNCPTR (gst_droidvideotexturesink_show_frame);
+
+  g_object_class_override_property (gobject_class, PROP_EGL_DISPLAY,
+      "egl-display");
+}
+
+static GstMemory *gst_droidvideotexturesink_get_droid_media_buffer_memory
+    (GstDroidVideoTextureSink * sink, GstBuffer * buffer)
+{
+  int x, num;
+
+  GST_DEBUG_OBJECT (sink, "get droid media buffer memory");
+
+  num = gst_buffer_n_memory (buffer);
+
+  GST_DEBUG_OBJECT (sink, "examining %d memory items", num);
+
+  for (x = 0; x < num; x++) {
+    GstMemory *mem = gst_buffer_peek_memory (buffer, x);
+
+    if (mem && gst_memory_is_type (mem, GST_ALLOCATOR_DROID_MEDIA_BUFFER)) {
+      return mem;
+    }
+  }
+
+  return NULL;
+}
+
+static gboolean
+gst_droidvideotexturesink_populate_egl_proc (GstDroidVideoTextureSink * sink)
+{
+  GST_DEBUG_OBJECT (sink, "populate egl proc");
+
+  if (G_UNLIKELY (!sink->eglDestroyImageKHR)) {
+    sink->eglDestroyImageKHR =
+        (PFNEGLDESTROYIMAGEKHRPROC) eglGetProcAddress ("eglDestroyImageKHR");
+  }
+
+  if (G_UNLIKELY (!sink->eglDestroyImageKHR)) {
+    return FALSE;
+  }
+
+  if (G_UNLIKELY (!sink->eglClientWaitSyncKHR)) {
+    sink->eglClientWaitSyncKHR = (PFNEGLCLIENTWAITSYNCKHRPROC)
+        eglGetProcAddress ("eglClientWaitSyncKHR");
+  }
+
+  if (G_UNLIKELY (!sink->eglClientWaitSyncKHR)) {
+    return FALSE;
+  }
+
+  if (G_UNLIKELY (!sink->eglDestroySyncKHR)) {
+    sink->eglDestroySyncKHR =
+        (PFNEGLDESTROYSYNCKHRPROC) eglGetProcAddress ("eglDestroySyncKHR");
+  }
+
+  if (G_UNLIKELY (!sink->eglDestroySyncKHR)) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/* interfaces */
+static gboolean
+gst_droidvideotexturesink_acquire_frame (NemoGstVideoTexture * iface)
+{
+  GstDroidVideoTextureSink *sink;
+  gboolean ret = TRUE;
+  GstMemory *mem;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (iface);
+
+  GST_DEBUG_OBJECT (sink, "acquire frame");
+
+  g_mutex_lock (&sink->lock);
+
+  if (sink->acquired_buffer) {
+    GST_WARNING_OBJECT (sink, "buffer %p already acquired",
+        sink->acquired_buffer);
+    ret = FALSE;
+    goto unlock_and_out;
+  }
+
+  if (!sink->last_buffer) {
+    GST_WARNING_OBJECT (sink, "no buffers available for acquisition");
+    ret = FALSE;
+    goto unlock_and_out;
+  }
+
+  mem =
+      gst_droidvideotexturesink_get_droid_media_buffer_memory (sink,
+      sink->last_buffer);
+
+  if (!mem) {
+    ret = FALSE;
+    GST_WARNING_OBJECT (sink, "no droidmedia buffer available");
+    goto unlock_and_out;
+  }
+
+  sink->acquired_buffer = gst_buffer_ref (sink->last_buffer);
+
+  if (!sink->acquired_buffer) {
+    ret = FALSE;
+    GST_INFO_OBJECT (sink, "failed to acquire a buffer");
+  }
+
+unlock_and_out:
+  g_mutex_unlock (&sink->lock);
+  return ret;
+}
+
+static gboolean
+gst_droidvideotexturesink_bind_frame (NemoGstVideoTexture * iface,
+    EGLImageKHR * image)
+{
+  GstDroidVideoTextureSink *sink;
+  gboolean ret = FALSE;
+  GstMemory *mem;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (iface);
+
+  GST_DEBUG_OBJECT (sink, "bind frame");
+
+  g_mutex_lock (&sink->lock);
+
+  if (sink->dpy == EGL_NO_DISPLAY) {
+    GST_WARNING_OBJECT (sink, "can not bind a frame without an EGLDisplay");
+    ret = FALSE;
+    goto unlock_and_out;
+  }
+
+  if (!gst_droidvideotexturesink_populate_egl_proc (sink)) {
+    GST_WARNING_OBJECT (sink, "failed to get needed EGL function pointers");
+    ret = FALSE;
+    goto unlock_and_out;
+  }
+
+  if (!sink->acquired_buffer) {
+    GST_WARNING_OBJECT (sink, "no frames have been acquired");
+    ret = FALSE;
+    goto unlock_and_out;
+  }
+
+  /* Now we are ready */
+
+  /* We can safely use peek here because we have an extra ref to the buffer */
+  mem =
+      gst_droidvideotexturesink_get_droid_media_buffer_memory (sink,
+      sink->acquired_buffer);
+  g_assert (mem);
+
+  sink->image =
+      nemo_gst_egl_image_memory_create_image (mem, sink->dpy, EGL_NO_CONTEXT);
+
+  /* Buffer will not go anywhere so we should be safe to unlock. */
+  g_mutex_unlock (&sink->lock);
+
+  *image = sink->image;
+
+  ret = TRUE;
+  goto out;
+
+unlock_and_out:
+  g_mutex_unlock (&sink->lock);
+
+out:
+  return ret;
+}
+
+static void
+gst_droidvideotexturesink_unbind_frame (NemoGstVideoTexture * iface)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (iface);
+
+  GST_DEBUG_OBJECT (sink, "unbind frame");
+
+  g_mutex_lock (&sink->lock);
+
+  if (sink->image == EGL_NO_IMAGE_KHR) {
+    GST_WARNING_OBJECT (sink, "Cannot unbind without a valid EGLImageKHR");
+    goto out;
+  }
+
+  if (sink->eglDestroyImageKHR (sink->dpy, sink->image) != EGL_TRUE) {
+    GST_WARNING_OBJECT (sink, "failed to destroy EGLImageKHR %p", sink->image);
+  }
+
+  sink->image = EGL_NO_IMAGE_KHR;
+
+out:
+  g_mutex_unlock (&sink->lock);
+}
+
+static void
+gst_droidvideotexturesink_release_frame (NemoGstVideoTexture * iface,
+    EGLSyncKHR sync)
+{
+  GstDroidVideoTextureSink *sink;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (iface);
+
+  GST_DEBUG_OBJECT (sink, "release frame");
+
+  g_mutex_lock (&sink->lock);
+
+  if (sink->acquired_buffer) {
+    gst_buffer_unref (sink->acquired_buffer);
+    sink->acquired_buffer = NULL;
+  }
+
+  g_mutex_unlock (&sink->lock);
+
+  /* Destroy any previous fence */
+  gst_droidvideotexturesink_wait_sync (sink);
+
+  /* move on */
+  sink->sync = sync;
+}
+
+static gboolean
+gst_droidvideotexturesink_get_frame_info (NemoGstVideoTexture * iface,
+    NemoGstVideoTextureFrameInfo * info)
+{
+  GstDroidVideoTextureSink *sink;
+  gboolean ret;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (iface);
+
+  GST_DEBUG_OBJECT (sink, "get frame info");
+
+  g_mutex_lock (&sink->lock);
+
+  if (!sink->acquired_buffer->pts) {
+    GST_INFO_OBJECT (sink, "no buffer has been acquired");
+
+    ret = FALSE;
+    goto unlock_and_out;
+  }
+
+  info->pts = sink->acquired_buffer->pts;
+  info->dts = sink->acquired_buffer->dts;
+  info->duration = sink->acquired_buffer->duration;
+  info->offset = sink->acquired_buffer->offset;
+  info->offset_end = sink->acquired_buffer->offset_end;
+
+  ret = TRUE;
+
+unlock_and_out:
+  g_mutex_unlock (&sink->lock);
+
+  return ret;
+}
+
+static GstMeta *
+gst_droidvideotexturesink_get_frame_meta (NemoGstVideoTexture * iface,
+    GType api)
+{
+  GstDroidVideoTextureSink *sink;
+  GstMeta *meta = NULL;
+
+  sink = GST_DROIDVIDEOTEXTURESINK (iface);
+
+  GST_DEBUG_OBJECT (sink, "get frame meta");
+
+  g_mutex_lock (&sink->lock);
+
+  if (sink->acquired_buffer) {
+    meta = gst_buffer_get_meta (sink->acquired_buffer, api);
+  }
+
+  g_mutex_unlock (&sink->lock);
+
+  return meta;
+}
+
+static void
+gst_droidvideotexturesink_video_texture_init (NemoGstVideoTextureClass * iface)
+{
+  iface->acquire_frame = gst_droidvideotexturesink_acquire_frame;
+  iface->bind_frame = gst_droidvideotexturesink_bind_frame;
+  iface->unbind_frame = gst_droidvideotexturesink_unbind_frame;
+  iface->release_frame = gst_droidvideotexturesink_release_frame;
+  iface->get_frame_info = gst_droidvideotexturesink_get_frame_info;
+  iface->get_frame_meta = gst_droidvideotexturesink_get_frame_meta;
+}

--- a/gst/droideglsink/gstdroidvideotexturesink.h
+++ b/gst/droideglsink/gstdroidvideotexturesink.h
@@ -1,0 +1,71 @@
+/*
+ * gst-droid
+ *
+ * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
+ * Copyright (C) 2015 Jolla LTD.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __GST_DROID_VIDEO_TEXTURE_SINK_H__
+#define __GST_DROID_VIDEO_TEXTURE_SINK_H__
+
+#include "gstdroideglsink.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_DROIDVIDEOTEXTURESINK \
+  (gst_droidvideotexturesink_get_type())
+#define GST_DROIDVIDEOTEXTURESINK(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_DROIDVIDEOTEXTURESINK, GstDroidVideoTextureSink))
+#define GST_DROIDVIDEOTEXTURESINK_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_DROIDVIDEOTEXTURESINK, GstDroidVideoTextureSinkClass))
+#define GST_IS_DROIDVIDEOTEXTURESINK(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_DROIDVIDEOTEXTURESINK))
+#define GST_IS_DROIDVIDEOTEXTURESINK_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_DROIDVIDEOTEXTURESINK))
+
+typedef struct _GstDroidVideoTextureSink GstDroidVideoTextureSink;
+typedef struct _GstDroidVideoTextureSinkClass GstDroidVideoTextureSinkClass;
+
+struct _GstDroidVideoTextureSink
+{
+  GstDroidEglSink parent;
+
+  gint fps_n;
+  gint fps_d;
+
+  GstBuffer *acquired_buffer;
+  GstBuffer *last_buffer;
+  EGLDisplay dpy;
+  EGLImageKHR image;
+  EGLSyncKHR sync;
+  GMutex lock;
+
+  PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
+  PFNEGLCLIENTWAITSYNCKHRPROC eglClientWaitSyncKHR;
+  PFNEGLDESTROYSYNCKHRPROC eglDestroySyncKHR;
+};
+
+struct _GstDroidVideoTextureSinkClass
+{
+  GstDroidEglSinkClass parent_class;
+};
+
+GType gst_droidvideotexturesink_get_type (void);
+
+G_END_DECLS
+
+#endif /* __GST_DROID_EGL_SINK_H__ */

--- a/gst/plugin.c
+++ b/gst/plugin.c
@@ -26,6 +26,7 @@
 #include "plugin.h"
 #include "gstdroidcamsrc.h"
 #include "gstdroideglsink.h"
+#include "gstdroidvideotexturesink.h"
 #include "gstdroidvdec.h"
 #include "gstdroidvenc.h"
 #include "gstdroidadec.h"
@@ -39,6 +40,7 @@ GST_DEBUG_CATEGORY (gst_droid_vdec_debug);
 GST_DEBUG_CATEGORY (gst_droid_venc_debug);
 GST_DEBUG_CATEGORY (gst_droid_codec_debug);
 GST_DEBUG_CATEGORY (gst_droid_eglsink_debug);
+GST_DEBUG_CATEGORY (gst_droid_videotexturesink_debug);
 
 static gboolean
 plugin_init (GstPlugin * plugin)
@@ -50,6 +52,9 @@ plugin_init (GstPlugin * plugin)
 
   GST_DEBUG_CATEGORY_INIT (gst_droid_eglsink_debug, "droideglsink",
       0, "Android EGL sink");
+
+  GST_DEBUG_CATEGORY_INIT (gst_droid_videotexturesink_debug,
+      "droidvideotexturesink", 0, "Android EGL sink");
 
   GST_DEBUG_CATEGORY_INIT (gst_droid_adec_debug, "droidadec",
       0, "Android HAL audio decoder");
@@ -70,6 +75,8 @@ plugin_init (GstPlugin * plugin)
       GST_TYPE_DROIDCAMSRC);
   ok &= gst_element_register (plugin, "droideglsink", GST_RANK_PRIMARY,
       GST_TYPE_DROIDEGLSINK);
+  ok &= gst_element_register (plugin, "droidvideotexturesink", GST_RANK_PRIMARY,
+      GST_TYPE_DROIDVIDEOTEXTURESINK);
 
   ok &= gst_element_register (plugin, "droidvdec", GST_RANK_PRIMARY + 1,
       GST_TYPE_DROIDVDEC);

--- a/rpm/gst-droid.spec
+++ b/rpm/gst-droid.spec
@@ -16,14 +16,14 @@ BuildRequires:  pkgconfig(gstreamer-base-1.0)
 BuildRequires:  pkgconfig(gstreamer-video-1.0)
 BuildRequires:  pkgconfig(gstreamer-plugins-bad-1.0)
 BuildRequires:  pkgconfig(gstreamer-tag-1.0)
-BuildRequires:  pkgconfig(nemo-gstreamer-interfaces-1.0)
+BuildRequires:  pkgconfig(nemo-gstreamer-interfaces-1.0) >= 0.20200421.0
 BuildRequires:  pkgconfig(libexif)
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  gettext
-BuildRequires:  droidmedia-devel >= 0.20191010.0
+BuildRequires:  droidmedia-devel >= 0.20200421.0
 BuildRequires:  pkgconfig(libandroid-properties)
-Requires:       droidmedia >= 0.20191010.0
+Requires:       droidmedia >= 0.20200421.0
 
 %description
 GStreamer droid plug-in contains elements using the Android HAL


### PR DESCRIPTION
We'd like to attach some persistent information to recycled buffers in a
sink and doing that requires recycling the buffer objects with a
persistent relationship to the underlying data objects.