### PR TITLE
[camera] Fix wrong byte-order on ISO value in EXIF. Fixes JB#50142

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrcexif.c
+++ b/gst/droidcamsrc/gstdroidcamsrcexif.c
@@ -160,11 +160,7 @@ gst_droidcamsrc_exif_tags_from_jpeg_data (void *data, size_t size)
       EXIF_TAG_ISO_SPEED_RATINGS);
 
   if (iso) {
-#ifdef __arm__
-    guint16 val = exif_get_short (iso->data, EXIF_BYTE_ORDER_MOTOROLA);
-#else
-    guint16 val = exif_get_short (iso->data, EXIF_BYTE_ORDER_INTEL);
-#endif
+    guint16 val = exif_get_short (iso->data, exif_data_get_byte_order(exif));
     gst_tag_list_add (tags, GST_TAG_MERGE_REPLACE,
         GST_TAG_CAPTURING_ISO_SPEED, val, NULL);
   }


### PR DESCRIPTION
Seems that endianness of ISO value in EXIF metadata inside captured file was detected according to CPU endianness.
That was wrong due to teh fact that endianness of EXIF data relates to camera driver that could send data in little- or big- endian (not depending of CPU).
That commit changes EXIF endianness detection to runtime using libexif's API.

Without this commit on some devices wrong ISO setting was saved inside JPEG file.
Rather than ISO 100 - value 25600 was saved.
Rather than ISO 1600 - value 16390 was saved.