### PR TITLE
Multiple Camera support

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.h
+++ b/gst/droidcamsrc/gstdroidcamsrc.h
@@ -48,7 +48,7 @@ G_BEGIN_DECLS
 #define GST_IS_DROIDCAMSRC_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_DROIDCAMSRC))
 
-#define MAX_CAMERAS 2
+#define MAX_CAMERAS 255
 #define GST_DROIDCAMSRC_CAPTURE_START "photo-capture-start"
 #define GST_DROIDCAMSRC_CAPTURE_END "photo-capture-end"
 #define GST_DROIDCAMSRC_PREVIEW_IMAGE "photo-capture-preview"
@@ -103,7 +103,7 @@ struct _GstDroidCamSrc
   GstDroidCamSrcMode *video;
   GstDroidCamSrcMode *active_mode;
 
-  GstDroidCamSrcCameraDevice camera_device;
+  int camera_device;
   GstCameraBinMode mode;
 
   int captures;

--- a/gst/droidcamsrc/gstdroidcamsrcenums.c
+++ b/gst/droidcamsrc/gstdroidcamsrcenums.c
@@ -26,24 +26,6 @@
 #include "gstdroidcamsrcenums.h"
 
 GType
-gst_droidcamsrc_camera_device_get_type (void)
-{
-  static GType gst_droidcamsrc_camera_device_type = 0;
-  static GEnumValue gst_droidcamsrc_camera_devices[] = {
-    {GST_DROIDCAMSRC_CAMERA_DEVICE_PRIMARY, "Primary camera", "primary"},
-    {GST_DROIDCAMSRC_CAMERA_DEVICE_SECONDARY, "Secondary camera", "secondary"},
-    {0, NULL, NULL},
-  };
-
-  if (G_UNLIKELY (!gst_droidcamsrc_camera_device_type)) {
-    gst_droidcamsrc_camera_device_type =
-        g_enum_register_static ("GstDroidCamSrcCameraDevice",
-        gst_droidcamsrc_camera_devices);
-  }
-  return gst_droidcamsrc_camera_device_type;
-}
-
-GType
 gst_droidcamsrc_image_mode_get_type (void)
 {
   static GType gst_droidcamsrc_image_mode_type = 0;

--- a/gst/droidcamsrc/gstdroidcamsrcenums.h
+++ b/gst/droidcamsrc/gstdroidcamsrcenums.h
@@ -26,15 +26,7 @@
 
 G_BEGIN_DECLS
 
-#define GST_TYPE_DROIDCAMSRC_CAMERA_DEVICE (gst_droidcamsrc_camera_device_get_type())
 #define GST_TYPE_DROIDCAMSRC_IMAGE_MODE (gst_droidcamsrc_image_mode_get_type())
-
-typedef enum {
-  GST_DROIDCAMSRC_CAMERA_DEVICE_PRIMARY = 0,
-  GST_DROIDCAMSRC_CAMERA_DEVICE_SECONDARY = 1,
-} GstDroidCamSrcCameraDevice;
-
-GType gst_droidcamsrc_camera_device_get_type (void);
 
 typedef enum {
   GST_DROIDCAMSRC_IMAGE_MODE_NORMAL = 0x0,


### PR DESCRIPTION
This is proof of concept initial multiple camera support. I dropped static `gst_droidcamsrc_camera_device_get_type`  enum and made `camera-device` an int. Facing of camera is being taken from android side, same as amount of cameras. If you want to get camera you don't get it by which side its facing but by it's id now. Also `gst/droidcamsrc/gstdroidcamsrc.c` got so many lines changed cause i reformatted it. I've increased MAX_CAMERAS to 255 (because of static array) and it's limited by camera-device property max value (which is amount of cameras). It's missing exposing which camera is facing which direction to qtmultimedia. This is only working proof of concept to be hopefully done properly by either community or jolla basing on it as it's beyond me (but hey… its working).

References to this PR https://git.sailfishos.org/mer-core/qtmultimedia/merge_requests/34