### PR TITLE
[spec] Fix package license. Contributes to JB#50383

### DIFF
--- a/rpm/gst-droid.spec
+++ b/rpm/gst-droid.spec
@@ -6,7 +6,7 @@ Summary:        GStreamer droid plug-in contains elements using the Android HAL
 Version:        1.0.0
 Release:        1
 Group:          Applications/Multimedia
-License:        LGPLv2.1+
+License:        LGPLv2+
 URL:            https://github.com/sailfishos/gst-droid
 Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  pkgconfig(egl)


### PR DESCRIPTION
Change license naming format to be the same as what Fedora is using at https://fedoraproject.org wiki/Licensing:Main#Software_License_List.