### PR TITLE
[gst-droid] Fps range fix

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -1694,11 +1694,7 @@ gst_droidcamsrc_vfsrc_negotiate (GstDroidCamSrcPad * data)
   our_caps = gst_caps_make_writable (our_caps);
   our_caps = gst_droidcamsrc_pick_largest_resolution (src, our_caps);
 
-  if (src->mode == MODE_IMAGE) {
-    gst_droidcamsrc_params_choose_image_framerate (src->dev->params, our_caps);
-  } else {
-    gst_droidcamsrc_params_choose_video_framerate (src->dev->params, our_caps);
-  }
+  gst_droidcamsrc_params_choose_framerate (src->dev->params, our_caps);
 
   if (!gst_pad_set_caps (data->pad, our_caps)) {
     GST_ERROR_OBJECT (src, "failed to set caps");
@@ -1858,7 +1854,7 @@ gst_droidcamsrc_imgsrc_negotiate (GstDroidCamSrcPad * data)
 
   our_caps = gst_caps_make_writable (our_caps);
   our_caps = gst_droidcamsrc_pick_largest_resolution (src, our_caps);
-  gst_droidcamsrc_params_choose_image_framerate (src->dev->params, our_caps);
+  gst_droidcamsrc_params_choose_framerate (src->dev->params, our_caps);
 
   if (!gst_pad_set_caps (data->pad, our_caps)) {
     GST_ERROR_OBJECT (src, "failed to set caps");

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -465,7 +465,7 @@ gst_droidcamsrc_params_get_string (GstDroidCamSrcParams * params,
 }
 
 void
-gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params,
+gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
     GstCaps * caps)
 {
   int x;
@@ -494,60 +494,8 @@ gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params,
     gst_caps_unref (c);
 
     /* the fps we have is valid. Select it if higher than our current target, or narrower */
-    /* Make the fps-range the same like gst_droidcamsrc_params_choose_video_framerate to set narrow fps range by of maximal valuee. */
-    /* Because Qualcomm camera HAL uses the max value of preview-fps-range, but MTK camera HAL uses the min value of preview-fps-range */
+    /* The Qualcomm camera HAL uses the max value of preview-fps-range, but MTK camera HAL uses the min value of preview-fps-range */
     /* the setting maximal values of min and max is doing the work of the viewfinder faster on MTK devices and still fast work of viewfinder on Qualcomm devices. */
-    if (max > target_max || (max == target_max && min > target_min)) {
-      target_min = min;
-      target_max = max;
-    }
-  }
-
-  if (target_min != -1 && target_max != -1) {
-    gchar *var;
-
-    /* use the max */
-    gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION,
-        target_max / 1000, 1, NULL);
-
-    var = g_strdup_printf ("%d,%d", target_min, target_max);
-    gst_droidcamsrc_params_set_string_locked (params, "preview-fps-range", var);
-    g_free (var);
-  }
-
-  g_mutex_unlock (&params->lock);
-}
-
-void
-gst_droidcamsrc_params_choose_video_framerate (GstDroidCamSrcParams * params,
-    GstCaps * caps)
-{
-  int x;
-  int target_min = -1, target_max = -1;
-
-  g_mutex_lock (&params->lock);
-
-  for (x = 0; x < params->min_fps_range->len; x++) {
-    int min = g_array_index (params->min_fps_range, gint, x);
-    int max = g_array_index (params->max_fps_range, gint, x);
-
-    GstCaps *c = gst_caps_copy (caps);
-    if (min == max) {
-      gst_caps_set_simple (c, "framerate", GST_TYPE_FRACTION, min / 1000, 1,
-          NULL);
-    } else {
-      gst_caps_set_simple (c, "framerate", GST_TYPE_FRACTION_RANGE,
-          min / 1000, 1, max / 1000, 1, NULL);
-    }
-
-    if (!gst_caps_can_intersect (caps, c)) {
-      gst_caps_unref (c);
-      continue;
-    }
-
-    gst_caps_unref (c);
-
-    /* the fps we have is valid. Select it if higher than our current target, or narrower */
     if (max > target_max || (max == target_max && min > target_min)) {
       target_min = min;
       target_max = max;

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -493,8 +493,11 @@ gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params,
 
     gst_caps_unref (c);
 
-    /* the fps we have is valid. Select it if higher than our current target, or wider */
-    if (max > target_max || (max == target_max && min < target_min)) {
+    /* the fps we have is valid. Select it if higher than our current target, or narrower */
+    /* Make the fps-range the same like gst_droidcamsrc_params_choose_video_framerate to set narrow fps range by of maximal valuee. */
+    /* Because Qualcomm camera HAL uses the max value of preview-fps-range, but MTK camera HAL uses the min value of preview-fps-range */
+    /* the setting maximal values of min and max is doing the work of the viewfinder faster on MTK devices and still fast work of viewfinder on Qualcomm devices. */
+    if (max > target_max || (max == target_max && min > target_min)) {
       target_min = min;
       target_max = max;
     }

--- a/gst/droidcamsrc/gstdroidcamsrcparams.h
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.h
@@ -55,8 +55,7 @@ const gchar *gst_droidcamsrc_params_get_string (GstDroidCamSrcParams * params, c
 int gst_droidcamsrc_params_get_int (GstDroidCamSrcParams * params, const char *key);
 float gst_droidcamsrc_params_get_float (GstDroidCamSrcParams * params, const char *key);
 
-void gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
-void gst_droidcamsrc_params_choose_video_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
+void gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 
 G_END_DECLS
 


### PR DESCRIPTION
The Qualcomm camera HAL uses the max value of preview-fps-range, but MTK camera HAL uses the min value of preview-fps-range.
The setting maximal values of min and max is doing the work of the viewfinder faster on MTK devices and still fast work of viewfinder on Qualcomm devices.
No any regression.