### PR TITLE
[gst-droid] Add jpeg-quality parameter to gstdroidcamsrc

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.h
+++ b/gst/droidcamsrc/gstdroidcamsrc.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2014 Mohammed Sameer
  * Copyright (C) 2016 Jolla Ltd.
  * Copyright (C) 2010 Texas Instruments, Inc
+ * Copyright (C) 2021 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -121,6 +122,7 @@ struct _GstDroidCamSrc
   gfloat ev_step;
 
   gint32 target_bitrate;
+  guint jpeg_quality;
 
   /* camerabin interface */
   gboolean post_preview;

--- a/gst/droidcamsrc/gstdroidcamsrcphotography.h
+++ b/gst/droidcamsrc/gstdroidcamsrcphotography.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
  * Copyright (C) 2015-2018 Jolla Ltd.
+ * Copyright (C) 2021 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -54,6 +55,7 @@ typedef enum
   PROP_SUPPORTED_FLASH_MODES,
   PROP_SUPPORTED_FOCUS_MODES,
   PROP_SUPPORTED_ISO_SPEEDS,
+  PROP_JPEG_QUALITY,
 
   /* photography interface */
   PROP_WB_MODE,


### PR DESCRIPTION
Add `jpeg-quality` parameter to configure quality of image that we receive from Android HAL. This change also improves default jpeg quality (in Android it is 90% by default) on devices that support `jpeg-quality` parameter. Usually camera app sets 100% quality in java code in Android. Our camera cannot control this parameter yet.

Reference: 
https://android.googlesource.com/platform/frameworks/av/+/master/camera/CameraParameters.cpp#45

https://android.googlesource.com/platform/frameworks/av/+/master/services/camera/libcameraservice/api1/client2/Parameters.cpp#370