### PR TITLE
[droidcamsrc] have buffer pool for raw buffers

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -1662,6 +1662,13 @@ gst_droidcamsrc_vfsrc_negotiate (GstDroidCamSrcPad * data)
   GstVideoInfo info;
   gboolean use_raw_data = TRUE;
   GstBufferPool *pool = NULL;
+  GstBufferPool *raw_pool = NULL;
+
+  gint i;
+  guint min, max;
+  guint size;
+  gint count;
+  GstQuery *query;
 
   g_rec_mutex_lock (&src->dev_lock);
 
@@ -1734,37 +1741,38 @@ gst_droidcamsrc_vfsrc_negotiate (GstDroidCamSrcPad * data)
       !gst_caps_features_contains (features,
       GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER);
 
+  /* Negotiate a buffer pool or allocate one now. Useful whether using queue
+   * buffers or not. Note that if raw_pool does not exist it'll be created
+   * inside dev as post_preview may also require it. */
+  query = gst_query_new_allocation (our_caps, TRUE);
+
+  if (!gst_pad_peer_query (data->pad, query)) {
+    GST_DEBUG_OBJECT (src, "didn't get downstream ALLOCATION hints");
+  }
+
+  count = gst_query_get_n_allocation_pools (query);
+
+  for (i = 0; i < count; ++i) {
+    GstAllocator *allocator;
+    GstStructure *config;
+
+    gst_query_parse_nth_allocation_pool (query, i, &pool, &size, &min, &max);
+    config = gst_buffer_pool_get_config (pool);
+    gst_buffer_pool_config_get_allocator (config, &allocator, NULL);
+    if (allocator
+        && g_strcmp0 (allocator->mem_type,
+            GST_ALLOCATOR_DROID_MEDIA_BUFFER) == 0) {
+      break;
+    } else if (!raw_pool) {
+      raw_pool = pool;
+      pool = NULL;
+    } else {
+      gst_object_unref (pool);
+      pool = NULL;
+    }
+  }
+
   if (!use_raw_data) {
-    /* Negotiate a buffer pool or allocate one now. */
-    gint i;
-    guint min, max;
-    guint size;
-    gint count;
-    GstQuery *query = gst_query_new_allocation (our_caps, TRUE);
-
-    if (!gst_pad_peer_query (data->pad, query)) {
-      GST_DEBUG_OBJECT (src, "didn't get downstream ALLOCATION hints");
-    }
-
-    count = gst_query_get_n_allocation_pools (query);
-
-    for (i = 0; i < count; ++i) {
-      GstAllocator *allocator;
-      GstStructure *config;
-
-      gst_query_parse_nth_allocation_pool (query, i, &pool, &size, &min, &max);
-      config = gst_buffer_pool_get_config (pool);
-      gst_buffer_pool_config_get_allocator (config, &allocator, NULL);
-      if (allocator
-          && g_strcmp0 (allocator->mem_type,
-              GST_ALLOCATOR_DROID_MEDIA_BUFFER) == 0) {
-        break;
-      } else {
-        gst_object_unref (pool);
-        pool = NULL;
-      }
-    }
-
     /* The downstream may have other ideas about what the pool size should be but the
      * queue we're working with has a fixed size so that's the number of buffers we'll
      * go with. */
@@ -1801,6 +1809,15 @@ gst_droidcamsrc_vfsrc_negotiate (GstDroidCamSrcPad * data)
     gst_object_unref (src->dev->pool);
   }
   src->dev->pool = pool;
+
+  /* Don't replace raw_pool unless we're given a new one. */
+  if (raw_pool) {
+    if (src->dev->raw_pool) {
+      gst_object_unref (src->dev->raw_pool);
+    }
+    src->dev->raw_pool = raw_pool;
+    src->dev->raw_pool_configured = FALSE;
+  }
 
   g_rec_mutex_unlock (&src->dev_lock);
 

--- a/gst/droidcamsrc/gstdroidcamsrcdev.c
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.c
@@ -282,13 +282,33 @@ gst_droidcamsrc_dev_preview_frame_callback (void *user,
   GstDroidCamSrc *src = GST_DROIDCAMSRC (GST_PAD_PARENT (dev->imgsrc->pad));
   GstDroidCamSrcPad *pad = dev->vfsrc;
   GstVideoInfo video_info;
-  GstBuffer *buffer;
+  GstBufferPool *pool;
+  GstBuffer *buffer = NULL;
   gsize width, height;
   DroidMediaRect rect;
 
   GST_DEBUG_OBJECT (src, "dev preview frame callback");
 
-  buffer = gst_buffer_new_allocate (NULL, mem->size, NULL);
+  pool = gst_object_ref (dev->raw_pool);
+  gst_buffer_pool_acquire_buffer (pool, &buffer, NULL);
+
+  if (buffer) {
+    gsize buffer_size = gst_buffer_get_size (buffer);
+    if (buffer_size < mem->size) {
+      /* Holy shit! We get the size wrong! */
+      GST_WARNING_OBJECT (src, "Raw buffer from the pool is too small! "
+            "(requires %ld, got %lu)",
+            (long) mem->size, (unsigned long) buffer_size);
+      /* Fail back to self-allocating. */
+      gst_buffer_replace (&buffer, NULL);
+    }
+  }
+
+  if (!buffer) {
+    GST_WARNING_OBJECT (src, "Fallback to self-allocating buffer.");
+    buffer = gst_buffer_new_allocate (NULL, mem->size, NULL);
+  }
+
   gst_buffer_fill (buffer, 0, mem->data, mem->size);
 
   GST_OBJECT_LOCK (src);
@@ -318,6 +338,8 @@ gst_droidcamsrc_dev_preview_frame_callback (void *user,
   } else {
     gst_buffer_unref (buffer);
   }
+
+  gst_object_unref (pool);
 }
 
 static void
@@ -548,6 +570,8 @@ gst_droidcamsrc_dev_new (GstDroidCamSrcPad * vfsrc,
   dev->lock = lock;
 
   dev->pool = NULL;
+  dev->raw_pool = NULL;
+  dev->raw_pool_configured = FALSE;
 
   dev->last_preview_buffer = NULL;
   g_mutex_init (&dev->last_preview_buffer_lock);
@@ -660,6 +684,10 @@ gst_droidcamsrc_dev_destroy (GstDroidCamSrcDev * dev)
 
   if (dev->pool) {
     gst_object_unref (dev->pool);
+  }
+
+  if (dev->raw_pool) {
+    gst_object_unref (dev->raw_pool);
   }
 
   gst_droidcamsrc_recorder_destroy (dev->recorder);
@@ -812,6 +840,11 @@ gst_droidcamsrc_dev_stop (GstDroidCamSrcDev * dev)
   g_queue_foreach (dev->vfsrc->queue, (GFunc) gst_buffer_unref, NULL);
   g_queue_clear (dev->vfsrc->queue);
   g_mutex_unlock (&dev->vfsrc->lock);
+
+  if (dev->raw_pool) {
+    gst_buffer_pool_set_active (dev->raw_pool, /* active */ FALSE);
+    dev->raw_pool_configured = FALSE;
+  }
 
   g_rec_mutex_unlock (dev->lock);
 }
@@ -1316,6 +1349,55 @@ gst_droidcamsrc_dev_queue_video_buffer_locked (GstDroidCamSrcDev * dev,
   g_cond_signal (&dev->vid->cond);
 }
 
+static void
+gst_droidcamsrc_dev_ensure_raw_pool_locked (GstDroidCamSrcDev * dev)
+{
+  GstDroidCamSrc *src = GST_DROIDCAMSRC (GST_PAD_PARENT (dev->imgsrc->pad));
+  GstCaps *caps = NULL;
+  GstStructure *config;
+  gint width, height;
+  gint min, max;
+  GstVideoInfo video_info;
+
+  if (dev->raw_pool && dev->raw_pool_configured) {
+    return;
+  }
+
+  if (!dev->raw_pool) {
+    dev->raw_pool = gst_buffer_pool_new ();
+  }
+
+  /* Configure the pool. */
+  /* TODO: research if this can results in a deadlock. */
+  GST_OBJECT_LOCK (src);
+  width = src->width;
+  height = src->height;
+  GST_OBJECT_UNLOCK (src);
+
+  gst_video_info_set_format (&video_info, GST_VIDEO_FORMAT_NV21, width, height);
+  caps = gst_video_info_to_caps (&video_info);
+
+  config = gst_buffer_pool_get_config (dev->raw_pool);
+
+  /* TODO: are these appropriate values? */
+  min = 0;
+  max = droid_media_buffer_queue_length ();
+  gst_buffer_pool_config_set_params (config, caps, video_info.size, min, max);
+
+  if (!gst_buffer_pool_set_config (dev->raw_pool, config) ||
+        !gst_buffer_pool_set_active (dev->raw_pool, /* active */ TRUE)) {
+    /* TODO: what should I do? */
+    GST_WARNING_OBJECT (src, "Can't configure raw buffer pool.");
+    goto out;
+  }
+
+  dev->raw_pool_configured = TRUE;
+
+out:
+
+  gst_caps_unref (caps);
+}
+
 void
 gst_droidcamsrc_dev_update_preview_callback_flag (GstDroidCamSrcDev * dev)
 {
@@ -1342,6 +1424,8 @@ gst_droidcamsrc_dev_update_preview_callback_flag (GstDroidCamSrcDev * dev)
   }
 
   if (use_preview_callback) {
+    gst_droidcamsrc_dev_ensure_raw_pool_locked (dev);
+
     droid_media_camera_set_preview_callback_flags (dev->cam,
         dev->c.CAMERA_FRAME_CALLBACK_FLAG_CAMERA);
   } else {

--- a/gst/droidcamsrc/gstdroidcamsrcdev.h
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.h
@@ -54,6 +54,8 @@ struct _GstDroidCamSrcDev
   GstDroidCamSrcImageCaptureState *img;
   GstDroidCamSrcVideoCaptureState *vid;
   GstBufferPool *pool;
+  GstBufferPool *raw_pool;
+  gboolean raw_pool_configured;
   DroidMediaCameraConstants c;
   GstVideoFormat viewfinder_format;
 


### PR DESCRIPTION
Now that post-preview option is suppoted, raw preview buffer will be
used more often. Thus, it make sense to use buffer pool with raw
preview buffer too.

This patch add code to ensure & configure buffer pool for raw buffers
whenever preview callback is required to be enabled. While at it, also
add support for buffer pool negotiation when using raw preview mode.
This reduces CPU usage as it longer repeatedly allocate memory.