### PR TITLE
[gst-droid] Fix capturing raw frames from vidsrc. JB#54913

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -1050,12 +1050,15 @@ gst_droidcamsrc_class_init (GstDroidCamSrcClass * klass)
   /* add raw caps */
   caps =
       gst_caps_merge (caps,
-      gst_caps_from_string (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
-          (GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "{YV12}")));
+      gst_caps_from_string (GST_VIDEO_CAPS_MAKE ("{YV12}")));
   caps =
       gst_caps_merge (caps,
       gst_caps_from_string (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
           (GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER, "{YV12}")));
+  caps =
+      gst_caps_merge (caps,
+      gst_caps_from_string (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
+          (GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "{YV12}")));
 
   tpl =
       gst_pad_template_new (GST_BASE_CAMERA_SRC_VIDEO_PAD_NAME, GST_PAD_SRC,

--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -1997,6 +1997,7 @@ gst_droidcamsrc_vidsrc_negotiate (GstDroidCamSrcPad * data)
   if (info.finfo->format == GST_VIDEO_FORMAT_ENCODED) {
     GST_INFO_OBJECT (src, "using external recorder");
     src->dev->use_recorder = TRUE;
+    src->dev->needs_meta_data_in_buffers = FALSE;
   } else {
     GST_INFO_OBJECT (src, "using raw recorder");
     src->dev->use_recorder = FALSE;
@@ -2006,6 +2007,12 @@ gst_droidcamsrc_vidsrc_negotiate (GstDroidCamSrcPad * data)
     use_raw_data =
         !gst_caps_features_contains (features,
         GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER);
+
+    src->dev->needs_meta_data_in_buffers =
+        gst_caps_features_contains (features,
+        GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER) |
+        gst_caps_features_contains (features,
+        GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA);
 
     if (!use_raw_data) {
       pool = gst_droidcamsrc_negotiate_buffer_pool (data, our_caps);

--- a/gst/droidcamsrc/gstdroidcamsrcdev.c
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.c
@@ -1400,11 +1400,13 @@ gst_droidcamsrc_dev_start_video_recording_raw_locked (GstDroidCamSrcDev * dev)
 {
   GstDroidCamSrc *src = GST_DROIDCAMSRC (GST_PAD_PARENT (dev->imgsrc->pad));
 
-  /* TODO: get that from caps */
-  if (!droid_media_camera_store_meta_data_in_buffers (dev->cam, true)) {
+  if (dev->needs_meta_data_in_buffers &&
+      !droid_media_camera_store_meta_data_in_buffers (dev->cam, true)) {
     GST_ELEMENT_ERROR (src, LIBRARY, SETTINGS,
         ("error storing meta data in buffers for video recording"), (NULL));
     return FALSE;
+  } else {
+    droid_media_camera_store_meta_data_in_buffers (dev->cam, false);
   }
 
   if (!droid_media_camera_start_recording (dev->cam)) {

--- a/gst/droidcamsrc/gstdroidcamsrcdev.h
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.h
@@ -41,6 +41,7 @@ struct _GstDroidCamSrcDev
 {
   DroidMediaCamera *cam;
   DroidMediaBufferQueue *queue;
+  DroidMediaBufferQueue *video_queue;
   GstDroidCamSrcParams *params;
   GstDroidCamSrcPad *vfsrc;
   GstDroidCamSrcPad *imgsrc;
@@ -54,6 +55,7 @@ struct _GstDroidCamSrcDev
   GstDroidCamSrcImageCaptureState *img;
   GstDroidCamSrcVideoCaptureState *vid;
   GstBufferPool *pool;
+  GstBufferPool *video_pool;
   DroidMediaCameraConstants c;
   GstVideoFormat viewfinder_format;
 

--- a/gst/droidcamsrc/gstdroidcamsrcdev.h
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.h
@@ -64,6 +64,7 @@ struct _GstDroidCamSrcDev
   GCond last_preview_buffer_cond;
 
   gboolean use_recorder;
+  gboolean needs_meta_data_in_buffers;
   GstDroidCamSrcRecorder *recorder;
 };
 

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -404,10 +404,15 @@ gst_droidcamsrc_params_get_video_caps (GstDroidCamSrcParams * params)
       params->has_separate_video_size_values ? "video-size-values" :
       "preview-size-values";
 
-  caps = gst_caps_merge (gst_droidcamsrc_params_get_caps_locked (params, key,
-          "video/x-raw", GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "YV12"),
+  caps = gst_droidcamsrc_params_get_caps_locked (params, key,
+      "video/x-raw", NULL, "YV12");
+  caps = gst_caps_merge (caps,
       gst_droidcamsrc_params_get_caps_locked (params, key,
           "video/x-raw", GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER,
+          "YV12"));
+  caps = gst_caps_merge (caps,
+      gst_droidcamsrc_params_get_caps_locked (params, key,
+          "video/x-raw", GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA,
           "YV12"));
 
   g_mutex_unlock (&params->lock);

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -404,8 +404,11 @@ gst_droidcamsrc_params_get_video_caps (GstDroidCamSrcParams * params)
       params->has_separate_video_size_values ? "video-size-values" :
       "preview-size-values";
 
-  caps = gst_droidcamsrc_params_get_caps_locked (params, key,
-      "video/x-raw", GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "YV12");
+  caps = gst_caps_merge (gst_droidcamsrc_params_get_caps_locked (params, key,
+          "video/x-raw", GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "YV12"),
+      gst_droidcamsrc_params_get_caps_locked (params, key,
+          "video/x-raw", GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER,
+          "YV12"));
 
   g_mutex_unlock (&params->lock);
 


### PR DESCRIPTION
This series of commits adds the use of the video queue introduced by https://github.com/sailfishos/droidmedia/pull/81. This fixes capturing raw frames from droidcamsrc's vidsrc using `video/x-raw(ANY)` media type format YV12. Depending on the device the result will be either `video/x-raw` or `video/x-raw(memory:DroidMediaQueueBuffer)` which is also can be mapped and accessed using precalculated frame size.