### PR TITLE
[gst-droid]  Drop libhybris dependency. JB#54878

### DIFF
--- a/gst-libs/gst/droid/meson.build
+++ b/gst-libs/gst/droid/meson.build
@@ -1,5 +1,4 @@
 gstdroid_sources = [
-  '/usr/share/droidmedia/hybris.c',
   'gstdroidbufferpool.c',
   'gstdroidcodec.c',
   'gstdroidmediabuffer.c',
@@ -16,7 +15,7 @@ gstdroid_headers = [
 ]
 
 gstdroid_deps = [
-  dl_dep,
+  droidmedia_dep,
   gst_dep,
   gstbase_dep,
   gstcodecparsers_dep,
@@ -30,7 +29,7 @@ install_headers(gstdroid_headers, subdir : 'gstreamer-@0@/gst/allocators'.format
 gstdroid = library('gstdroid-@0@'.format(api_version),
   gstdroid_sources + gstdroid_headers,
   c_args : gstdroid_args + ['-DGST_USE_UNSTABLE_API'],
-  include_directories : [configinc, libsinc, droidmedia_h],
+  include_directories : [configinc, libsinc],
   version : lib_version,
   soversion : so_version,
   install : true,

--- a/gst-libs/gst/droid/meson.build
+++ b/gst-libs/gst/droid/meson.build
@@ -16,13 +16,13 @@ gstdroid_headers = [
 ]
 
 gstdroid_deps = [
+  dl_dep,
   gst_dep,
   gstbase_dep,
   gstcodecparsers_dep,
   gstvideo_dep,
   egl_dep,
   gstnemointerfaces_dep,
-  hybris_dep
 ]
 
 install_headers(gstdroid_headers, subdir : 'gstreamer-@0@/gst/allocators'.format(api_version))

--- a/gst/droidcamsrc/meson.build
+++ b/gst/droidcamsrc/meson.build
@@ -24,6 +24,7 @@ gstdroidcamsrc_headers = [
 ]
 
 gstdroidcamsrc_deps = [
+  dl_dep,
   gst_dep,
   gstbase_dep,
   gstcamerabinsrc_dep,
@@ -34,7 +35,6 @@ gstdroidcamsrc_deps = [
   gstvideo_dep,
   egl_dep,
   exif_dep,
-  hybris_dep
 ]
 
 gstdroidcamsrc = static_library('gstdroidcamsrc-@0@'.format(api_version),

--- a/gst/droidcamsrc/meson.build
+++ b/gst/droidcamsrc/meson.build
@@ -1,5 +1,4 @@
 gstdroidcamsrc_sources = [
-  '/usr/share/droidmedia/hybris.c',
   'gstdroidcamsrc.c',
   'gstdroidcamsrcdev.c',
   'gstdroidcamsrcparams.c',
@@ -24,7 +23,7 @@ gstdroidcamsrc_headers = [
 ]
 
 gstdroidcamsrc_deps = [
-  dl_dep,
+  droidmedia_dep,
   gst_dep,
   gstbase_dep,
   gstcamerabinsrc_dep,
@@ -40,7 +39,7 @@ gstdroidcamsrc_deps = [
 gstdroidcamsrc = static_library('gstdroidcamsrc-@0@'.format(api_version),
   gstdroidcamsrc_sources + gstdroidcamsrc_headers,
   c_args : gstdroid_args + ['-DGST_USE_UNSTABLE_API'],
-  include_directories : ['..', configinc, libsinc, droidmedia_h],
+  include_directories : ['..', configinc, libsinc],
   dependencies : gstdroidcamsrc_deps
 )
 

--- a/gst/droidcodec/meson.build
+++ b/gst/droidcodec/meson.build
@@ -1,5 +1,4 @@
 gstdroidcodec_sources = [
-  '/usr/share/droidmedia/hybris.c',
   'gstdroidvdec.c',
   'gstdroidvenc.c',
   'gstdroidadec.c',
@@ -14,7 +13,7 @@ gstdroidcodec_headers = [
 ]
 
 gstdroidcodec_deps = [
-  dl_dep,
+  droidmedia_dep,
   gst_dep,
   gstaudio_dep,
   gstbase_dep,
@@ -28,7 +27,7 @@ gstdroidcodec_deps = [
 gstdroidcodec = static_library('gstdroidcodec-@0@'.format(api_version),
   gstdroidcodec_sources + gstdroidcodec_headers,
   c_args : gstdroid_args + ['-DGST_USE_UNSTABLE_API'],
-  include_directories : ['..', configinc, libsinc, droidmedia_h],
+  include_directories : ['..', configinc, libsinc],
   dependencies : gstdroidcodec_deps
 )
 

--- a/gst/droidcodec/meson.build
+++ b/gst/droidcodec/meson.build
@@ -14,6 +14,7 @@ gstdroidcodec_headers = [
 ]
 
 gstdroidcodec_deps = [
+  dl_dep,
   gst_dep,
   gstaudio_dep,
   gstbase_dep,
@@ -21,7 +22,6 @@ gstdroidcodec_deps = [
   gstdroid_dep,
   gstvideo_dep,
   egl_dep,
-  hybris_dep,
   orc_dep
 ]
 

--- a/gst/droideglsink/meson.build
+++ b/gst/droideglsink/meson.build
@@ -1,5 +1,4 @@
 gstdroideglsink_sources = [
-  '/usr/share/droidmedia/hybris.c',
   'gstdroideglsink.c',
   'gstdroidvideotexturesink.c'
 ]
@@ -10,7 +9,7 @@ gstdroideglsink_headers = [
 ]
 
 gstdroideglsink_deps = [
-  dl_dep,
+  droidmedia_dep,
   gst_dep,
   gstdroid_dep,
   gstnemointerfaces_dep,
@@ -21,7 +20,7 @@ gstdroideglsink_deps = [
 gstdroideglsink = static_library('gstdroideglsink-@0@'.format(api_version),
   gstdroideglsink_sources + gstdroideglsink_headers,
   c_args : gstdroid_args + ['-DGST_USE_UNSTABLE_API'],
-  include_directories : ['..', configinc, libsinc, droidmedia_h],
+  include_directories : ['..', configinc, libsinc],
   dependencies : gstdroideglsink_deps
 )
 

--- a/gst/droideglsink/meson.build
+++ b/gst/droideglsink/meson.build
@@ -10,6 +10,7 @@ gstdroideglsink_headers = [
 ]
 
 gstdroideglsink_deps = [
+  dl_dep,
   gst_dep,
   gstdroid_dep,
   gstnemointerfaces_dep,

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -15,7 +15,7 @@ libgstdroid = library('gstdroid',
   libgstdroid_sources + libgstdroid_headers,
   c_args : gstdroid_args + ['-DGST_USE_UNSTABLE_API'],
   include_directories : [configinc, libsinc, droidmedia_h, 'droidcamsrc', 'droidcodec', 'droideglsink'],
-  dependencies : [ gst_dep, gstdroidcamsrc_dep, gstdroidcodec_dep, gstdroideglsink_dep, hybris_dep ],
+  dependencies : [ gst_dep, gstdroidcamsrc_dep, gstdroidcodec_dep, gstdroideglsink_dep, dl_dep ],
   install : true,
   install_dir : plugins_install_dir,
 )

--- a/gst/meson.build
+++ b/gst/meson.build
@@ -1,5 +1,4 @@
 libgstdroid_sources = [
-  '/usr/share/droidmedia/hybris.c',
   'plugin.c',
 ]
 
@@ -14,8 +13,8 @@ subdir('droidcamsrc')
 libgstdroid = library('gstdroid',
   libgstdroid_sources + libgstdroid_headers,
   c_args : gstdroid_args + ['-DGST_USE_UNSTABLE_API'],
-  include_directories : [configinc, libsinc, droidmedia_h, 'droidcamsrc', 'droidcodec', 'droideglsink'],
-  dependencies : [ gst_dep, gstdroidcamsrc_dep, gstdroidcodec_dep, gstdroideglsink_dep, dl_dep ],
+  include_directories : [configinc, libsinc, 'droidcamsrc', 'droidcodec', 'droideglsink'],
+  dependencies : [ gst_dep, gstdroidcamsrc_dep, gstdroidcodec_dep, gstdroideglsink_dep, droidmedia_dep ],
   install : true,
   install_dir : plugins_install_dir,
 )

--- a/gst/plugin.c
+++ b/gst/plugin.c
@@ -89,7 +89,7 @@ plugin_init (GstPlugin * plugin)
       GST_TYPE_DROIDAENC);
 
   if (ok)
-    droid_media_init ();
+    ok = droid_media_init ();
 
   return ok;
 }

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ droid_conf.set_quoted('PACKAGE_STRING', 'GstDroid library')
 
 root_dir = include_directories('.')
 droidmedia_h = include_directories('/usr/include/droidmedia')
-hybris_dep = cc.find_library('hybris-common', required: true)
+dl_dep = cc.find_library('dl', required: true)
 
 gstdroid_args = ['-DHAVE_CONFIG_H', '-DSYSCONFDIR="/etc"']
 

--- a/meson.build
+++ b/meson.build
@@ -50,8 +50,7 @@ droid_conf.set_quoted('PACKAGE_NAME', 'GstDroid library')
 droid_conf.set_quoted('PACKAGE_STRING', 'GstDroid library')
 
 root_dir = include_directories('.')
-droidmedia_h = include_directories('/usr/include/droidmedia')
-dl_dep = cc.find_library('dl', required: true)
+droidmedia_dep = dependency('droidmedia', required : true)
 
 gstdroid_args = ['-DHAVE_CONFIG_H', '-DSYSCONFDIR="/etc"']
 

--- a/rpm/gst-droid.spec
+++ b/rpm/gst-droid.spec
@@ -5,7 +5,6 @@ Name:           %{gstreamer}%{majorminor}-droid
 Summary:        GStreamer droid plug-in contains elements using the Android HAL
 Version:        1.0.0
 Release:        1
-Group:          Applications/Multimedia
 License:        LGPLv2+
 URL:            https://github.com/sailfishos/gst-droid
 Source0:        %{name}-%{version}.tar.gz
@@ -19,8 +18,8 @@ BuildRequires:  pkgconfig(gstreamer-tag-1.0)
 BuildRequires:  pkgconfig(nemo-gstreamer-interfaces-1.0) >= 0.20200421.0
 BuildRequires:  pkgconfig(libexif)
 BuildRequires:  meson
-BuildRequires:  droidmedia-devel >= 0.20200421.0
-Requires:       droidmedia >= 0.20200421.0
+BuildRequires:  pkgconfig(droidmedia)
+Requires:       droidmedia
 
 %description
 GStreamer droid plug-in contains elements using the Android HAL

--- a/rpm/gst-droid.spec
+++ b/rpm/gst-droid.spec
@@ -20,7 +20,6 @@ BuildRequires:  pkgconfig(nemo-gstreamer-interfaces-1.0) >= 0.20200421.0
 BuildRequires:  pkgconfig(libexif)
 BuildRequires:  meson
 BuildRequires:  droidmedia-devel >= 0.20200421.0
-BuildRequires:  pkgconfig(libandroid-properties)
 Requires:       droidmedia >= 0.20200421.0
 
 %description

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -4,7 +4,7 @@ executable('dump-resolutions',
   ['common.c', 'resolutions.c'],
   install: true,
   c_args : gstdroid_args,
-  include_directories : [configinc, libsinc, droidmedia_h],
+  include_directories : [configinc, libsinc],
   dependencies : tool_deps,
 )
 
@@ -12,6 +12,6 @@ executable('dump-camera-parameters',
   ['common.c', 'gstdroidcamparams.c'],
   install: true,
   c_args : gstdroid_args,
-  include_directories : [configinc, libsinc, droidmedia_h],
+  include_directories : [configinc, libsinc],
   dependencies : tool_deps,
 )


### PR DESCRIPTION
Link gst-droid against droidmedia wrapper, so the dependency on droidmedia becomes weak and the source can be built in a hardware-agnostic project.