### PR TITLE
Fix selecting video framerate

### DIFF
--- a/gst-libs/gst/droid/gstdroidcodec.c
+++ b/gst-libs/gst/droid/gstdroidcodec.c
@@ -929,7 +929,7 @@ create_aacdec_codec_data_from_frame_data (GstDroidCodec * codec,
 
   GST_WRITE_UINT16_BE (codec_data, codec_data_data);
 
-  data = gst_buffer_new_and_alloc (2);
+  data = gst_buffer_new_allocate(NULL, 2, NULL);
   gst_buffer_fill (data, 0, codec_data, 2);
 
   ret = create_aacdec_codec_data_from_codec_data (codec, data, out);

--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -454,7 +454,7 @@ gst_droidcamsrc_set_property (GObject * object, guint prop_id,
         new_caps = gst_caps_ref (new_caps);
       }
 
-      if (!gst_caps_is_equal (src->preview_caps, new_caps)) {
+      if (!src->preview_caps || !gst_caps_is_equal (src->preview_caps, new_caps)) {
         gst_caps_replace (&src->preview_caps, new_caps);
 
         if (src->preview_pipeline) {
@@ -1311,7 +1311,7 @@ out:
     GST_DEBUG_OBJECT (pad, "Pushing SEGMENT");
 
     if (data->adjust_segment) {
-      data->segment.start = GST_BUFFER_TIMESTAMP (buffer);
+      data->segment.start = GST_BUFFER_PTS (buffer);
     }
 
     event = gst_event_new_segment (&data->segment);
@@ -1708,7 +1708,7 @@ gst_droidcamsrc_vfsrc_negotiate (GstDroidCamSrcPad * data)
     gst_droidcamsrc_params_choose_video_framerate (src->dev->params, our_caps);
   }
 
-  if (!gst_pad_set_caps (data->pad, our_caps)) {
+  if (!gst_pad_push_event (data->pad, gst_event_new_caps (our_caps))) {
     GST_ERROR_OBJECT (src, "failed to set caps");
     goto out;
   }
@@ -1868,7 +1868,7 @@ gst_droidcamsrc_imgsrc_negotiate (GstDroidCamSrcPad * data)
   our_caps = gst_droidcamsrc_pick_largest_resolution (src, our_caps);
   gst_droidcamsrc_params_choose_image_framerate (src->dev->params, our_caps);
 
-  if (!gst_pad_set_caps (data->pad, our_caps)) {
+  if (!gst_pad_push_event (data->pad, gst_event_new_caps (our_caps))) {
     GST_ERROR_OBJECT (src, "failed to set caps");
     goto out;
   }
@@ -1947,7 +1947,7 @@ gst_droidcamsrc_vidsrc_negotiate (GstDroidCamSrcPad * data)
   gst_structure_fixate_field_nearest_fraction (gst_caps_get_structure (our_caps,
           0), "framerate", G_MAXINT, 1);
 
-  if (!gst_pad_set_caps (data->pad, our_caps)) {
+  if (!gst_pad_push_event (data->pad, gst_event_new_caps (our_caps))) {
     GST_ERROR_OBJECT (src, "failed to set caps");
     goto out;
   }

--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -1940,12 +1940,7 @@ gst_droidcamsrc_vidsrc_negotiate (GstDroidCamSrcPad * data)
   our_caps = gst_caps_make_writable (our_caps);
   our_caps = gst_droidcamsrc_pick_largest_resolution (src, our_caps);
 
-  /* just in case.
-   * TODO: a better way of doing it is to get the current fps preview range and use its
-   * upper bound
-   */
-  gst_structure_fixate_field_nearest_fraction (gst_caps_get_structure (our_caps,
-          0), "framerate", G_MAXINT, 1);
+  gst_droidcamsrc_params_choose_framerate (src->dev->params, our_caps, FALSE, NULL);
 
   if (!gst_pad_push_event (data->pad, gst_event_new_caps (our_caps))) {
     GST_ERROR_OBJECT (src, "failed to set caps");

--- a/gst/droidcamsrc/gstdroidcamsrcparams.h
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.h
@@ -55,6 +55,8 @@ const gchar *gst_droidcamsrc_params_get_string (GstDroidCamSrcParams * params, c
 int gst_droidcamsrc_params_get_int (GstDroidCamSrcParams * params, const char *key);
 float gst_droidcamsrc_params_get_float (GstDroidCamSrcParams * params, const char *key);
 
+void gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
+  GstCaps * caps, gboolean widest, const char *set_param);
 void gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 void gst_droidcamsrc_params_choose_video_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 

--- a/gst/droidcamsrc/gstdroidcamsrcrecorder.c
+++ b/gst/droidcamsrc/gstdroidcamsrcrecorder.c
@@ -149,7 +149,7 @@ gst_droidcamsrc_recorder_data_available (void *data,
     current = NULL;
 
     gst_caps_set_simple (caps, "codec_data", GST_TYPE_BUFFER, codec_data, NULL);
-    ret = gst_pad_set_caps (recorder->vidsrc->pad, caps);
+    ret = gst_pad_push_event (recorder->vidsrc->pad, gst_event_new_caps (caps));
     gst_caps_unref (caps);
 
     if (!ret) {

--- a/gst/droidcodec/gstdroidaenc.c
+++ b/gst/droidcodec/gstdroidaenc.c
@@ -520,7 +520,7 @@ gst_droidaenc_handle_frame (GstAudioEncoder * encoder, GstBuffer * buffer)
  * encoder's clock, as some versions of libstagefright throw away frames if
  * it doesn't increase
  */
-  GstClockTime ts = GST_BUFFER_TIMESTAMP (buffer);
+  GstClockTime ts = GST_BUFFER_PTS (buffer);
   if (!GST_CLOCK_TIME_IS_VALID (ts)) {
     GST_DEBUG_OBJECT (enc, "Replacing invalid timestamp: %" GST_TIME_FORMAT,
         GST_TIME_ARGS (ts));

--- a/gst/droideglsink/gstdroidvideotexturesink.c
+++ b/gst/droideglsink/gstdroidvideotexturesink.c
@@ -112,8 +112,8 @@ gst_droidvideotexturesink_get_times (GstBaseSink * bsink, GstBuffer * buf,
 
   sink = GST_DROIDVIDEOTEXTURESINK (bsink);
 
-  if (GST_BUFFER_TIMESTAMP_IS_VALID (buf)) {
-    *start = GST_BUFFER_TIMESTAMP (buf);
+  if (GST_BUFFER_PTS_IS_VALID (buf)) {
+    *start = GST_BUFFER_PTS (buf);
     if (GST_BUFFER_DURATION_IS_VALID (buf)) {
       *end = *start + GST_BUFFER_DURATION (buf);
     } else {


### PR DESCRIPTION
Remove usage of deprecated functions and macros.
Silence warning when setting initial preview caps.