### PR TITLE
[gst-droid] Fix dark video preview. JB#57323

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2014 Mohammed Sameer
  * Copyright (C) 2015-2021 Jolla Ltd.
  * Copyright (C) 2010 Texas Instruments, Inc
- * Copyright (C) 2021 Open Mobile Platform LLC.
+ * Copyright (C) 2021-2022 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -1971,7 +1971,7 @@ gst_droidcamsrc_vidsrc_negotiate (GstDroidCamSrcPad * data)
   our_caps = gst_caps_make_writable (our_caps);
   our_caps = gst_droidcamsrc_pick_largest_resolution (src, our_caps);
 
-  gst_droidcamsrc_params_choose_framerate (src->dev->params, our_caps, FALSE, NULL);
+  gst_droidcamsrc_params_choose_framerate (src->dev->params, our_caps, NULL);
 
   if (!gst_pad_push_event (data->pad, gst_event_new_caps (our_caps))) {
     GST_ERROR_OBJECT (src, "failed to set caps");

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -517,7 +517,7 @@ gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
     if (set_param_name) {
       gchar *var;
       var = g_strdup_printf ("%d,%d", target_min, target_max);
-      gst_droidcamsrc_params_set_string_locked (params, "preview-fps-range", var);
+      gst_droidcamsrc_params_set_string_locked (params, set_param_name, var);
       g_free (var);
     }
   }

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Mohammed Sameer
  * Copyright (C) 2015-2021 Jolla Ltd.
+ * Copyright (C) 2022 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -466,7 +467,7 @@ gst_droidcamsrc_params_get_string (GstDroidCamSrcParams * params,
 
 void
 gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
-    GstCaps * caps, gboolean widest, const char *set_param_name)
+    GstCaps * caps, const char *set_param_name)
 {
   int x;
   int target_min = -1, target_max = -1;
@@ -493,18 +494,10 @@ gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
 
     gst_caps_unref (c);
 
-    if (widest) {
-      /* the fps we have is valid. Select it if higher than our current target, or wider */
-      if (max > target_max || (max == target_max && min < target_min)) {
-        target_min = min;
-        target_max = max;
-      }
-    } else {
-      /* the fps we have is valid. Select it if higher than our current target, or narrower */
-      if (max > target_max || (max == target_max && min > target_min)) {
-        target_min = min;
-        target_max = max;
-      }
+    /* the fps we have is valid. Select it if higher than our current target, or wider */
+    if (max > target_max || (max == target_max && min < target_min)) {
+      target_min = min;
+      target_max = max;
     }
   }
 
@@ -530,7 +523,7 @@ gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params,
     GstCaps * caps)
 {
   gst_droidcamsrc_params_choose_framerate (params,
-    caps, TRUE, "preview-fps-range");
+    caps, "preview-fps-range");
 }
 
 void
@@ -538,5 +531,5 @@ gst_droidcamsrc_params_choose_video_framerate (GstDroidCamSrcParams * params,
     GstCaps * caps)
 {
   gst_droidcamsrc_params_choose_framerate (params,
-    caps, FALSE, "preview-fps-range");
+    caps, "preview-fps-range");
 }

--- a/gst/droidcamsrc/gstdroidcamsrcparams.h
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.h
@@ -56,7 +56,7 @@ int gst_droidcamsrc_params_get_int (GstDroidCamSrcParams * params, const char *k
 float gst_droidcamsrc_params_get_float (GstDroidCamSrcParams * params, const char *key);
 
 void gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
-  GstCaps * caps, gboolean widest, const char *set_param);
+  GstCaps * caps, gboolean widest, const char *set_param_name);
 void gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 void gst_droidcamsrc_params_choose_video_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 

--- a/gst/droidcamsrc/gstdroidcamsrcparams.h
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2014 Mohammed Sameer <msameer@foolab.org>
  * Copyright (C) 2015-2018 Jolla Ltd.
+ * Copyright (C) 2022 Open Mobile Platform LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -56,7 +57,7 @@ int gst_droidcamsrc_params_get_int (GstDroidCamSrcParams * params, const char *k
 float gst_droidcamsrc_params_get_float (GstDroidCamSrcParams * params, const char *key);
 
 void gst_droidcamsrc_params_choose_framerate (GstDroidCamSrcParams * params,
-  GstCaps * caps, gboolean widest, const char *set_param_name);
+  GstCaps * caps, const char *set_param_name);
 void gst_droidcamsrc_params_choose_image_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 void gst_droidcamsrc_params_choose_video_framerate (GstDroidCamSrcParams * params, GstCaps * caps);
 


### PR DESCRIPTION
This MR changes FPS selection behaviour for video viewfinder preview.
Now it will choose `wider` values in range, for ex. now (5;30) will be preferred
than (30;30). This allows camera to sensor drop actual framerate to setup
exposure time correctly.

This will also fix behavior when manual exposure cannot be set (higher than 0)
for some camera sensors.