### PR TITLE
[gst-droid] Fix a couple compiler warnings. JB#62364

### DIFF
--- a/gst-libs/gst/droid/gstdroidcodec.c
+++ b/gst-libs/gst/droid/gstdroidcodec.c
@@ -45,8 +45,6 @@ static gboolean create_h264dec_codec_data_from_codec_data (GstDroidCodec *
     codec, GstBuffer * data, DroidMediaData * out);
 static gboolean create_h265dec_codec_data_from_codec_data (GstDroidCodec *
     codec, GstBuffer * data, DroidMediaData * out);
-static gboolean create_av1dec_codec_data_from_codec_data (GstDroidCodec *
-    codec, GstBuffer * data, DroidMediaData * out);
 static gboolean create_aacdec_codec_data_from_codec_data (GstDroidCodec * codec,
     GstBuffer * data, DroidMediaData * out);
 static gboolean create_aacdec_codec_data_from_frame_data (GstDroidCodec * codec,

--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -1579,6 +1579,9 @@ gst_droidcamsrc_pad_query (GstPad * pad, GstObject * parent, GstQuery * query)
 #if GST_CHECK_VERSION(1,16,0)
     case GST_QUERY_BITRATE:
 #endif
+#if GST_CHECK_VERSION(1,22,0)
+    case GST_QUERY_SELECTABLE:
+#endif
       ret = FALSE;
       break;
 
@@ -2667,7 +2670,7 @@ static gboolean
 gst_droidcamsrc_update_jpeg_quality(GstDroidCamSrc * src)
 {
   gboolean ret = FALSE;
-  const gchar* str = NULL;
+  gchar* str = NULL;
   gint jpeg_quality = 0;
 
   GST_DEBUG_OBJECT (src, "update jpeg quality");


### PR DESCRIPTION
- Gstreamer 1.22 added selectable enum value which resulted in compiler warning for not handled case.
- The str variable was warning for const qualifier being omitted, and a deallocation is somewhat non-const operation.
- Av1 codec static function wasn't used and didn't have implementation, seems dead code.