### PR TITLE
[gst-droid] Circumvent critical error 'index < array->len'

### DIFF
--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -967,6 +967,11 @@ gst_droidvdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
       if (!gst_buffer_pool_set_config (pool, config)) {
         GST_ERROR_OBJECT (decoder, "Failed to set buffer pool configuration");
       }
+
+      gint count = gst_query_get_n_allocation_pools (query);
+      if (count == 0) {
+        gst_query_add_allocation_pool(query, pool, size, min, max);
+      }
     }
 
     gst_query_set_nth_allocation_pool (query, 0, pool, size, min, max);


### PR DESCRIPTION
Under certain conditions the following critical error is triggered:

GStreamer-CRITICAL **: 21:38:48.274: gst_query_set_nth_allocation_pool:
  assertion 'index < array->len' failed

Situations in which this happens include:
1. Destroying a video before it's been played.
2. Streaming a video to two outputs.

It appears to be caused by a call to gst_droidvdec_decide_allocation() where the query has no allocated pools. In this case a pool is created as a fallback, but because the query is empty, when an attempt is made to add the fallback pool, there's no entry for it to be inserted into. This triggers the critical error when the array length is zero.

This change adds the pool to the query explicitly if these specific conditions are satisified, thereby ensuring there's an entry in the query for the pool allocation to be added to.