### PR TITLE
Configure media buffers through quirks

### DIFF
--- a/gst-libs/gst/droid/gstdroidcodec.c
+++ b/gst-libs/gst/droid/gstdroidcodec.c
@@ -1161,6 +1161,10 @@ gst_droid_codec_type_fill_quirks (GstDroidCodec * codec)
       codec->quirks |= USE_CODEC_SUPPLIED_WIDTH_VALUE;
     } else if (!g_strcmp0 (quirks_string[x], DONT_USE_DROID_CONVERT_NAME)) {
       codec->quirks |= DONT_USE_DROID_CONVERT_VALUE;
+    } else if (!g_strcmp0 (quirks_string[x], FORCE_MEDIA_BUFFERS_NAME)) {
+      codec->quirks |= FORCE_MEDIA_BUFFERS_VALUE;
+    } else if (!g_strcmp0 (quirks_string[x], NO_MEDIA_BUFFERS_NAME)) {
+      codec->quirks |= NO_MEDIA_BUFFERS_VALUE;
     }
   }
 

--- a/gst-libs/gst/droid/gstdroidcodec.h
+++ b/gst-libs/gst/droid/gstdroidcodec.h
@@ -35,8 +35,14 @@ G_BEGIN_DECLS
 #define USE_CODEC_SUPPLIED_WIDTH_NAME    "use-codec-supplied-width"
 #define USE_CODEC_SUPPLIED_WIDTH_VALUE   0x2
 
-#define DONT_USE_DROID_CONVERT_NAME    "dont-use-droid-convert"
-#define DONT_USE_DROID_CONVERT_VALUE   0x4
+#define DONT_USE_DROID_CONVERT_NAME      "dont-use-droid-convert"
+#define DONT_USE_DROID_CONVERT_VALUE     0x4
+
+#define FORCE_MEDIA_BUFFERS_NAME         "force-media-buffers"
+#define FORCE_MEDIA_BUFFERS_VALUE        0x8
+
+#define NO_MEDIA_BUFFERS_NAME            "no-media-buffers"
+#define NO_MEDIA_BUFFERS_VALUE           0x10
 
 typedef struct _GstDroidCodec GstDroidCodec;
 typedef struct _GstDroidCodecInfo GstDroidCodecInfo;

--- a/gst/droidcodec/gstdroidvdec.c
+++ b/gst/droidcodec/gstdroidvdec.c
@@ -1138,6 +1138,8 @@ gst_droidvdec_set_format (GstVideoDecoder * decoder, GstVideoCodecState * state)
   GstCaps *caps, *template_caps;
   guint i, count;
   gboolean created_now = FALSE;
+  gboolean force_media_buffers = FALSE;
+  gboolean disable_media_buffers = FALSE;
 
   /*
    * destroying the droidmedia codec here will cause stagefright to call abort.
@@ -1175,14 +1177,26 @@ gst_droidvdec_set_format (GstVideoDecoder * decoder, GstVideoCodecState * state)
 
   GST_DEBUG_OBJECT (dec, "peer caps %" GST_PTR_FORMAT, caps);
 
-  dec->use_hardware_buffers = FALSE;
+  force_media_buffers =
+      !!(dec->codec_type->quirks & FORCE_MEDIA_BUFFERS_VALUE);
+  disable_media_buffers =
+      !!(dec->codec_type->quirks & NO_MEDIA_BUFFERS_VALUE);
 
   count = gst_caps_get_size (caps);
-  for (i = 0; i < count; ++i) {
-    GstCapsFeatures *features = gst_caps_get_features (caps, i);
-    if (gst_caps_features_contains
-        (features, GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER)) {
-      dec->use_hardware_buffers = TRUE;
+  if (force_media_buffers && !disable_media_buffers) {
+    dec->use_hardware_buffers = TRUE;
+    GST_INFO_OBJECT (dec, "forcing media-buffer output path via codec quirk");
+  } else if (disable_media_buffers) {
+    dec->use_hardware_buffers = FALSE;
+    GST_INFO_OBJECT (dec, "disabling media-buffer output path via codec quirk");
+  } else {
+    dec->use_hardware_buffers = FALSE;
+    for (i = 0; i < count; ++i) {
+      GstCapsFeatures *features = gst_caps_get_features (caps, i);
+      if (gst_caps_features_contains
+          (features, GST_CAPS_FEATURE_MEMORY_DROID_MEDIA_QUEUE_BUFFER)) {
+        dec->use_hardware_buffers = TRUE;
+      }
     }
   }
 


### PR DESCRIPTION
Allows to configure either `no-media-buffers` or `force-media-buffers` just as on gecko-camera,