### PR TITLE
Improve droidcamsrc cold-start speed.

### DIFF
--- a/gst/droidcamsrc/gstdroidcamsrc.c
+++ b/gst/droidcamsrc/gstdroidcamsrc.c
@@ -65,14 +65,11 @@ GST_STATIC_PAD_TEMPLATE (GST_BASE_CAMERA_SRC_IMAGE_PAD_NAME,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS ("image/jpeg"));
 
-#if 0
 static GstStaticPadTemplate vid_src_template_factory =
 GST_STATIC_PAD_TEMPLATE (GST_BASE_CAMERA_SRC_VIDEO_PAD_NAME,
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
-        (GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "{YV12}")));
-#endif
+    GST_STATIC_CAPS_ANY);
 
 static gboolean gst_droidcamsrc_pad_activate_mode (GstPad * pad,
     GstObject * parent, GstPadMode mode, gboolean active);
@@ -126,6 +123,13 @@ static guint droidcamsrc_signals[LAST_SIGNAL];
 #define DEFAULT_JPEG_QUALITY           90
 #define DEFAULT_MIN_JPEG_QUALITY       10
 #define DEFAULT_MAX_JPEG_QUALITY       100
+
+#define CAMERA_STARTUP_CREATE(format, ...) \
+  G_STMT_START { \
+    if (gst_droid_camera_startup_logging_enabled ()) \
+      g_message ("CAMERA_STARTUP gst-droid-create %" G_GINT64_FORMAT " ms " format, \
+          gst_droid_camera_startup_mono_ms (), ##__VA_ARGS__); \
+  } G_STMT_END
 
 static GstDroidCamSrcPad *
 gst_droidcamsrc_create_pad (GstDroidCamSrc * src,
@@ -285,7 +289,11 @@ gst_droidcamsrc_get_property (GObject * object, guint prop_id, GValue * value,
       break;
 
     case PROP_SENSOR_DIRECTION:
-      g_value_set_int (value, src->info[src->camera_device].direction);
+      if (!gst_droidcamsrc_get_hw (src)) {
+        g_value_set_int (value, 0);
+      } else {
+        g_value_set_int (value, src->info[src->camera_device].direction);
+      }
       break;
 
     case PROP_SENSOR_MOUNT_ANGLE:
@@ -734,6 +742,11 @@ gst_droidcamsrc_change_state (GstElement * element, GstStateChange transition)
         ret = GST_STATE_CHANGE_FAILURE;
       }
 
+      if (ret != GST_STATE_CHANGE_FAILURE) {
+        gst_droidcamsrc_dev_update_params (src->dev);
+        gst_droidcamsrc_update_max_zoom (src);
+      }
+
       src->captures = 0;
       g_object_notify (G_OBJECT (src), "ready-for-capture");
 
@@ -1052,8 +1065,8 @@ gst_droidcamsrc_class_init (GstDroidCamSrcClass * klass)
 {
   GObjectClass *gobject_class;
   GstElementClass *gstelement_class;
-  GstCaps *caps;
-  GstPadTemplate *tpl;
+
+  CAMERA_STARTUP_CREATE ("class_init begin");
 
   gobject_class = (GObjectClass *) klass;
   gstelement_class = (GstElementClass *) klass;
@@ -1065,21 +1078,13 @@ gst_droidcamsrc_class_init (GstDroidCamSrcClass * klass)
   gst_element_class_add_pad_template (gstelement_class,
       gst_static_pad_template_get (&vf_src_template_factory));
 
+
   gst_element_class_add_pad_template (gstelement_class,
       gst_static_pad_template_get (&img_src_template_factory));
-
-  /* encoded caps */
-  caps = gst_droid_codec_get_all_caps (GST_DROID_CODEC_ENCODER_VIDEO);
-
-  /* add raw caps */
-  caps =
-      gst_caps_merge (caps,
-      gst_caps_from_string (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
-          (GST_CAPS_FEATURE_MEMORY_DROID_VIDEO_META_DATA, "{YV12}")));
-  tpl =
-      gst_pad_template_new (GST_BASE_CAMERA_SRC_VIDEO_PAD_NAME, GST_PAD_SRC,
-      GST_PAD_ALWAYS, caps);
-  gst_element_class_add_pad_template (gstelement_class, tpl);
+  /* Avoid codec enumeration during type initialization. Detailed video caps
+   * are queried lazily when configuring video capture. */
+  gst_element_class_add_pad_template (gstelement_class,
+      gst_static_pad_template_get (&vid_src_template_factory));
 
   gobject_class->set_property = gst_droidcamsrc_set_property;
   gobject_class->get_property = gst_droidcamsrc_get_property;
@@ -1090,12 +1095,14 @@ gst_droidcamsrc_class_init (GstDroidCamSrcClass * klass)
   gstelement_class->send_event = GST_DEBUG_FUNCPTR (gst_droidcamsrc_send_event);
 
   /* Add camera-device property only if cameras have been found */
-  if (droid_media_camera_get_number_of_cameras () > 0) {
+  CAMERA_STARTUP_CREATE ("camera count begin");
+  gint camera_count = droid_media_camera_get_number_of_cameras ();
+  CAMERA_STARTUP_CREATE ("camera count done count=%d", camera_count);
+  if (camera_count > 0) {
     g_object_class_install_property (gobject_class, PROP_CAMERA_DEVICE,
         g_param_spec_int ("camera-device", "Camera device",
             "Defines which camera device should be used",
-            0,
-            droid_media_camera_get_number_of_cameras () - 1,
+            0, camera_count - 1,
             DEFAULT_CAMERA_DEVICE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   }
 
@@ -1254,6 +1261,8 @@ gst_droidcamsrc_class_init (GstDroidCamSrcClass * klass)
       G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
       G_CALLBACK (gst_droidcamsrc_stop_capture),
       NULL, NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
+
+  CAMERA_STARTUP_CREATE ("class_init done");
 }
 
 static void

--- a/gst/droidcamsrc/gstdroidcamsrcdev.c
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.c
@@ -24,6 +24,7 @@
 #include <config.h>
 #endif
 
+#include "../plugin.h"
 #include "gstdroidcamsrcdev.h"
 #include <stdlib.h>
 #include "gstdroidcamsrc.h"
@@ -42,6 +43,17 @@
 
 GST_DEBUG_CATEGORY_EXTERN (gst_droid_camsrc_debug);
 #define GST_CAT_DEFAULT gst_droid_camsrc_debug
+
+#define CAMERA_STARTUP_DEV(format, ...) \
+  G_STMT_START { \
+    if (gst_droid_camera_startup_logging_enabled ()) \
+      g_message ("CAMERA_STARTUP gst-droid-dev %" G_GINT64_FORMAT " ms " format, \
+          gst_droid_camera_startup_mono_ms (), ##__VA_ARGS__); \
+  } G_STMT_END
+
+#define CAMERA_STARTUP_DEV_ALWAYS(format, ...) \
+  g_message ("CAMERA_STARTUP gst-droid-dev %" G_GINT64_FORMAT " ms " format, \
+      gst_droid_camera_startup_mono_ms (), ##__VA_ARGS__)
 
 #define VIDEO_RECORDING_STOP_TIMEOUT                 100000     /* us */
 #define GST_DROIDCAMSRC_NUM_BUFFERS                  2
@@ -286,6 +298,11 @@ gst_droidcamsrc_dev_preview_frame_callback (void *user,
   DroidMediaRect rect;
 
   GST_DEBUG_OBJECT (src, "dev preview frame callback");
+  if (!dev->first_preview_frame_seen) {
+    dev->first_preview_frame_seen = TRUE;
+    CAMERA_STARTUP_DEV_ALWAYS ("first raw preview callback size=%" G_GSIZE_FORMAT " use_raw_data=%d",
+        (gsize) mem->size, dev->use_raw_data);
+  }
 
   buffer = gst_buffer_new_allocate (NULL, mem->size, NULL);
   gst_buffer_fill (buffer, 0, mem->data, mem->size);
@@ -472,6 +489,10 @@ gst_droidcamsrc_dev_frame_available (void *user, DroidMediaBuffer * buffer)
   DroidMediaBufferInfo info;
 
   GST_DEBUG_OBJECT (src, "frame available");
+  if (!dev->first_frame_available_seen) {
+    dev->first_frame_available_seen = TRUE;
+    CAMERA_STARTUP_DEV_ALWAYS ("first buffer-queue frame available use_raw_data=%d", dev->use_raw_data);
+  }
 
   droid_media_buffer_get_info (buffer, &info);
 
@@ -580,9 +601,12 @@ gst_droidcamsrc_dev_open (GstDroidCamSrcDev * dev, GstDroidCamSrcCamInfo * info)
   src = GST_DROIDCAMSRC (GST_PAD_PARENT (dev->imgsrc->pad));
 
   GST_DEBUG_OBJECT (src, "dev open");
+  CAMERA_STARTUP_DEV ("dev_open begin camera=%d", info ? info->num : -1);
 
   dev->info = info;
+  CAMERA_STARTUP_DEV ("droid_media_camera_connect begin camera=%d", dev->info->num);
   dev->cam = droid_media_camera_connect (dev->info->num);
+  CAMERA_STARTUP_DEV ("droid_media_camera_connect done camera=%d cam=%p", dev->info->num, dev->cam);
 
   if (!dev->cam) {
     g_rec_mutex_unlock (dev->lock);
@@ -625,6 +649,7 @@ gst_droidcamsrc_dev_open (GstDroidCamSrcDev * dev, GstDroidCamSrcCamInfo * info)
 
   g_rec_mutex_unlock (dev->lock);
 
+  CAMERA_STARTUP_DEV ("dev_open done camera=%d", dev->info->num);
   return TRUE;
 }
 
@@ -738,6 +763,8 @@ gst_droidcamsrc_dev_start (GstDroidCamSrcDev * dev, gboolean apply_settings)
   gboolean ret = FALSE;
   GstDroidCamSrc *src = GST_DROIDCAMSRC (GST_PAD_PARENT (dev->imgsrc->pad));
 
+  CAMERA_STARTUP_DEV ("dev_start begin apply_settings=%d running=%d use_raw_data=%d",
+      apply_settings, dev->running, dev->use_raw_data);
   g_rec_mutex_lock (dev->lock);
 
   if (dev->running) {
@@ -762,18 +789,25 @@ gst_droidcamsrc_dev_start (GstDroidCamSrcDev * dev, gboolean apply_settings)
   }
 
   if (apply_settings) {
+    CAMERA_STARTUP_DEV ("apply_mode_settings from dev_start begin");
     gst_droidcamsrc_apply_mode_settings (src, SET_ONLY);
+    CAMERA_STARTUP_DEV ("apply_mode_settings from dev_start done");
   }
 
   /* now set params */
+  CAMERA_STARTUP_DEV ("dev_set_params from dev_start begin");
   if (!gst_droidcamsrc_dev_set_params (dev)) {
     goto out;
   }
 
+  CAMERA_STARTUP_DEV ("dev_set_params from dev_start done");
+
+  CAMERA_STARTUP_DEV ("droid_media_camera_start_preview begin");
   if (!droid_media_camera_start_preview (dev->cam)) {
     GST_ERROR_OBJECT (src, "error starting preview");
     goto out;
   }
+  CAMERA_STARTUP_DEV ("droid_media_camera_start_preview done");
 
   dev->running = TRUE;
 
@@ -788,6 +822,7 @@ out:
   }
 
   g_rec_mutex_unlock (dev->lock);
+  CAMERA_STARTUP_DEV ("dev_start done ret=%d running=%d", ret, dev->running);
   return ret;
 }
 
@@ -844,13 +879,15 @@ gst_droidcamsrc_dev_set_params (GstDroidCamSrcDev * dev)
   params = gst_droidcamsrc_params_to_string (dev->params);
   GST_LOG ("setting parameters %s", params);
   err = droid_media_camera_set_parameters (dev->cam, params);
-  g_free (params);
 
   if (!err) {
     GST_ERROR ("error setting parameters");
+    g_free (params);
     goto out;
   }
 
+  gst_droidcamsrc_params_mark_clean (dev->params);
+  g_free (params);
   ret = TRUE;
 
 out:

--- a/gst/droidcamsrc/gstdroidcamsrcdev.h
+++ b/gst/droidcamsrc/gstdroidcamsrcdev.h
@@ -49,6 +49,8 @@ struct _GstDroidCamSrcDev
   GstAllocator *media_allocator;
   gboolean running;
   gboolean use_raw_data;
+  gboolean first_preview_frame_seen;
+  gboolean first_frame_available_seen;
   GRecMutex *lock;
   GstDroidCamSrcCamInfo *info;
   GstDroidCamSrcImageCaptureState *img;

--- a/gst/droidcamsrc/gstdroidcamsrcmode.c
+++ b/gst/droidcamsrc/gstdroidcamsrcmode.c
@@ -92,13 +92,13 @@ gst_droidcamsrc_mode_activate (GstDroidCamSrcMode * mode)
 
   if (running) {
     ret = gst_droidcamsrc_dev_start (mode->src->dev, FALSE);
-  } else {
-    ret = gst_droidcamsrc_apply_params (mode->src);
-  }
 
-  /* now update max-zoom that we have a preview size */
-  gst_droidcamsrc_dev_update_params (mode->src->dev);
-  gst_droidcamsrc_update_max_zoom (mode->src);
+    /* now update max-zoom that we have a preview size */
+    gst_droidcamsrc_dev_update_params (mode->src->dev);
+    gst_droidcamsrc_update_max_zoom (mode->src);
+  } else {
+    ret = TRUE;
+  }
 
   g_rec_mutex_unlock (&mode->src->dev_lock);
 

--- a/gst/droidcamsrc/gstdroidcamsrcparams.c
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.c
@@ -271,8 +271,6 @@ gst_droidcamsrc_params_to_string (GstDroidCamSrcParams * params)
     }
   }
 
-  params->is_dirty = FALSE;
-
   g_mutex_unlock (&params->lock);
 
   return string;
@@ -288,6 +286,14 @@ gst_droidcamsrc_params_is_dirty (GstDroidCamSrcParams * params)
   g_mutex_unlock (&params->lock);
 
   return is_dirty;
+}
+
+void
+gst_droidcamsrc_params_mark_clean (GstDroidCamSrcParams * params)
+{
+  g_mutex_lock (&params->lock);
+  params->is_dirty = FALSE;
+  g_mutex_unlock (&params->lock);
 }
 
 static GstCaps *

--- a/gst/droidcamsrc/gstdroidcamsrcparams.h
+++ b/gst/droidcamsrc/gstdroidcamsrcparams.h
@@ -46,6 +46,7 @@ void gst_droidcamsrc_params_reload (GstDroidCamSrcParams *params, const gchar * 
 
 gchar *gst_droidcamsrc_params_to_string (GstDroidCamSrcParams *params);
 gboolean gst_droidcamsrc_params_is_dirty (GstDroidCamSrcParams *params);
+void gst_droidcamsrc_params_mark_clean (GstDroidCamSrcParams *params);
 
 GstCaps *gst_droidcamsrc_params_get_viewfinder_caps (GstDroidCamSrcParams *params, GstVideoFormat format);
 GstCaps *gst_droidcamsrc_params_get_video_caps (GstDroidCamSrcParams *params);

--- a/gst/plugin.c
+++ b/gst/plugin.c
@@ -43,10 +43,19 @@ GST_DEBUG_CATEGORY (gst_droid_codec_debug);
 GST_DEBUG_CATEGORY (gst_droid_eglsink_debug);
 GST_DEBUG_CATEGORY (gst_droid_videotexturesink_debug);
 
+#define CAMERA_STARTUP_PLUGIN(format, ...) \
+  G_STMT_START { \
+    if (gst_droid_camera_startup_logging_enabled ()) \
+      g_message ("CAMERA_STARTUP gst-droid-plugin %" G_GINT64_FORMAT " ms " format, \
+          gst_droid_camera_startup_mono_ms (), ##__VA_ARGS__); \
+  } G_STMT_END
+
 static gboolean
 plugin_init (GstPlugin * plugin)
 {
   gboolean ok = TRUE;
+
+  CAMERA_STARTUP_PLUGIN ("plugin_init begin");
 
   GST_DEBUG_CATEGORY_INIT (gst_droid_camsrc_debug, "droidcamsrc",
       0, "Android HAL camera source");
@@ -72,12 +81,17 @@ plugin_init (GstPlugin * plugin)
   GST_DEBUG_CATEGORY_INIT (gst_droid_codec_debug, "droidcodec",
       0, "Android HAL codec");
 
+  CAMERA_STARTUP_PLUGIN ("debug categories done");
+
   ok &= gst_element_register (plugin, "droidcamsrc", GST_RANK_PRIMARY,
       GST_TYPE_DROIDCAMSRC);
+  CAMERA_STARTUP_PLUGIN ("registered droidcamsrc ok=%d", ok);
   ok &= gst_element_register (plugin, "droideglsink", GST_RANK_PRIMARY,
       GST_TYPE_DROIDEGLSINK);
   ok &= gst_element_register (plugin, "droidvideotexturesink", GST_RANK_PRIMARY,
       GST_TYPE_DROIDVIDEOTEXTURESINK);
+
+  CAMERA_STARTUP_PLUGIN ("registered sinks ok=%d", ok);
 
   ok &= gst_element_register (plugin, "droidvdec", GST_RANK_PRIMARY + 1,
       GST_TYPE_DROIDVDEC);
@@ -88,8 +102,15 @@ plugin_init (GstPlugin * plugin)
   ok &= gst_element_register (plugin, "droidaenc", GST_RANK_PRIMARY + 1,
       GST_TYPE_DROIDAENC);
 
-  if (ok)
+  CAMERA_STARTUP_PLUGIN ("registered codecs ok=%d", ok);
+
+  if (ok) {
+    CAMERA_STARTUP_PLUGIN ("droid_media_init begin");
     ok = droid_media_init ();
+    CAMERA_STARTUP_PLUGIN ("droid_media_init done ok=%d", ok);
+  }
+
+  CAMERA_STARTUP_PLUGIN ("plugin_init done ok=%d", ok);
 
   return ok;
 }

--- a/gst/plugin.h
+++ b/gst/plugin.h
@@ -25,6 +25,18 @@
 
 G_BEGIN_DECLS
 
+static inline gboolean
+gst_droid_camera_startup_logging_enabled (void)
+{
+  return g_getenv ("CAMERA_STARTUP_LOG") != NULL;
+}
+
+static inline gint64
+gst_droid_camera_startup_mono_ms (void)
+{
+  return g_get_monotonic_time () / G_TIME_SPAN_MILLISECOND;
+}
+
 G_END_DECLS
 
 #endif /* __PLUGIN_H__ */


### PR DESCRIPTION
Delay video encoder caps enumeration until video capture configuration so droidcamsrc class initialization no longer pays the cold codec query cost.

Do not apply mode parameters before preview is running, and only mark camera parameters clean after they were accepted by the HAL.

Add CAMERA_STARTUP markers around plugin registration, camera open/start, and first preview frame. Gate most markers with CAMERA_STARTUP_LOG, while always emitting the first-frame marker for startup evaluation.